### PR TITLE
Add culture-specific formatting for numbers and date/time

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,6 +62,7 @@ if(LUNARLOG_BUILD_TESTS)
             test/tests/test_operators.cpp
             test/tests/test_template_handling.cpp
             test/tests/test_filtering.cpp
+            test/tests/test_culture_formatting.cpp
             test/tests/utils/test_utils.cpp
     )
 

--- a/include/lunar_log/core/log_common.hpp
+++ b/include/lunar_log/core/log_common.hpp
@@ -7,6 +7,16 @@
 #include <cstdio>
 #include <cstdint>
 #include <memory>
+#include <sstream>
+#include <iomanip>
+#include <locale>
+#include <cstdlib>
+#include <cerrno>
+#include <cmath>
+#include <climits>
+#include <vector>
+#include <unordered_map>
+#include <utility>
 
 namespace minta {
 namespace detail {
@@ -55,6 +65,400 @@ namespace detail {
         std::snprintf(buf + pos, sizeof(buf) - pos, ".%03d", static_cast<int>((nowMs.count() + 1000) % 1000));
         return std::string(buf);
     }
+    // ----------------------------------------------------------------
+    // Format helpers (shared by LunarLog and detail::reformatMessage)
+    // ----------------------------------------------------------------
+
+    /// Safely parse an integer from a string. Returns fallback on failure.
+    inline int safeStoi(const std::string &s, int fallback = 0) {
+        if (s.empty()) return fallback;
+        for (size_t i = 0; i < s.size(); ++i) {
+            if (!std::isdigit(static_cast<unsigned char>(s[i]))) return fallback;
+        }
+        try { return std::stoi(s); } catch (...) { return fallback; }
+    }
+
+    /// Try to parse a string as a double. Returns true on success and sets out.
+    inline bool tryParseDouble(const std::string &s, double &out) {
+        if (s.empty()) return false;
+        const char* start = s.c_str();
+        char* end = nullptr;
+        errno = 0;
+        double val = std::strtod(start, &end);
+        if (errno == ERANGE || end == start || static_cast<size_t>(end - start) != s.size()) {
+            errno = 0;
+            return false;
+        }
+        errno = 0;
+        if (std::isinf(val) || std::isnan(val)) return false;
+        out = val;
+        return true;
+    }
+
+    inline double clampForLongLong(double val) {
+        if (val != val) return 0.0;
+        static const double kMinLL = static_cast<double>(LLONG_MIN + 1);
+        static const double kMaxLL = std::nextafter(static_cast<double>(LLONG_MAX), 0.0);
+        if (val < kMinLL) return kMinLL;
+        if (val > kMaxLL) return kMaxLL;
+        return val;
+    }
+
+    /// Format a double into a string using the given printf format.
+    inline std::string snprintfDouble(const char* fmt, double val) {
+        int needed = std::snprintf(nullptr, 0, fmt, val);
+        if (needed < 0) return std::string();
+        if (static_cast<size_t>(needed) < 256) {
+            char stackBuf[256];
+            std::snprintf(stackBuf, sizeof(stackBuf), fmt, val);
+            return std::string(stackBuf);
+        }
+        std::vector<char> heapBuf(static_cast<size_t>(needed) + 1);
+        std::snprintf(heapBuf.data(), heapBuf.size(), fmt, val);
+        return std::string(heapBuf.data());
+    }
+
+    /// Format a double with precision.
+    inline std::string snprintfDoublePrecision(const char* fmt, int precision, double val) {
+        int needed = std::snprintf(nullptr, 0, fmt, precision, val);
+        if (needed < 0) return std::string();
+        if (static_cast<size_t>(needed) < 256) {
+            char stackBuf[256];
+            std::snprintf(stackBuf, sizeof(stackBuf), fmt, precision, val);
+            return std::string(stackBuf);
+        }
+        std::vector<char> heapBuf(static_cast<size_t>(needed) + 1);
+        std::snprintf(heapBuf.data(), heapBuf.size(), fmt, precision, val);
+        return std::string(heapBuf.data());
+    }
+
+    /// Split "name:spec" into (name, spec). Returns (placeholder, "") if no colon.
+    inline std::pair<std::string, std::string> splitPlaceholder(const std::string &placeholder) {
+        size_t colonPos = placeholder.rfind(':');
+        if (colonPos == std::string::npos) {
+            return std::make_pair(placeholder, std::string());
+        }
+        return std::make_pair(placeholder.substr(0, colonPos), placeholder.substr(colonPos + 1));
+    }
+
+    // ----------------------------------------------------------------
+    // Culture-specific formatting utilities
+    // ----------------------------------------------------------------
+
+    inline std::locale tryCreateLocale(const std::string& name) {
+        if (name.empty() || name == "C" || name == "POSIX") {
+            return std::locale::classic();
+        }
+        // Thread-local multi-entry cache: handles the realistic multi-sink
+        // case (3-4 locales) without thrashing. Capped at 8 entries to
+        // prevent unbounded growth from programmatic locale creation.
+        thread_local std::unordered_map<std::string, std::locale> cache;
+        auto it = cache.find(name);
+        if (it != cache.end()) {
+            return it->second;
+        }
+        std::locale result = std::locale::classic();
+        try {
+            result = std::locale(name);
+        } catch (...) {
+            if (name.find('.') == std::string::npos) {
+                try {
+                    result = std::locale(name + ".UTF-8");
+                } catch (...) {}
+            }
+        }
+        if (cache.size() < 8) {
+            cache.emplace(name, result);
+        }
+        return result;
+    }
+
+    /// Format a number with locale-specific thousand/decimal separators.
+    /// Used by the :n and :N format specs.
+    inline std::string formatCultureNumber(const std::string& value, const std::string& localeName) {
+        double numVal;
+        if (!tryParseDouble(value, numVal)) return value;
+
+        std::locale loc = tryCreateLocale(localeName);
+        std::ostringstream oss;
+        oss.imbue(loc);
+
+        bool hasSciNotation = (value.find('e') != std::string::npos ||
+                               value.find('E') != std::string::npos);
+        if (hasSciNotation) {
+            oss << std::fixed << std::setprecision(6) << numVal;
+        } else {
+            size_t dotPos = value.find('.');
+            int precision = 0;
+            if (dotPos != std::string::npos) {
+                precision = static_cast<int>(value.size() - dotPos - 1);
+                if (precision > 15) precision = 15;
+            }
+            oss << std::fixed << std::setprecision(precision) << numVal;
+        }
+        return oss.str();
+    }
+
+    /// Format a unix timestamp as a locale-aware date/time string.
+    /// Used by the :d, :D, :t, :T, :f, :F format specs.
+    inline std::string formatCultureDateTime(const std::string& value, char spec, const std::string& localeName) {
+        double tsVal;
+        if (!tryParseDouble(value, tsVal)) return value;
+
+        time_t t = static_cast<time_t>(tsVal);
+        std::tm tmBuf;
+#if defined(_MSC_VER)
+        localtime_s(&tmBuf, &t);
+#else
+        localtime_r(&t, &tmBuf);
+#endif
+
+        const char* fmt = nullptr;
+        switch (spec) {
+            case 'd': fmt = "%x"; break;                           // short date
+            case 'D': fmt = "%A, %B %d, %Y"; break;               // long date
+            case 't': fmt = "%H:%M"; break;                        // short time
+            case 'T': fmt = "%H:%M:%S"; break;                     // long time
+            case 'f': fmt = "%A, %B %d, %Y %H:%M"; break;         // full date + short time
+            case 'F': fmt = "%A, %B %d, %Y %H:%M:%S"; break;      // full date + long time
+            default: return value;
+        }
+
+        std::locale loc = tryCreateLocale(localeName);
+        std::ostringstream oss;
+        oss.imbue(loc);
+        oss << std::put_time(&tmBuf, fmt);
+        std::string result = oss.str();
+        return result.empty() ? value : result;
+    }
+
+    // ----------------------------------------------------------------
+    // Complete format spec application with locale support
+    // ----------------------------------------------------------------
+
+    /// Apply a format spec to a string value, with optional locale for culture specs.
+    /// Handles all existing specs (.Nf, Nf, C, X, E, P, 0N) plus culture specs (n, N, d, D, t, T, f, F).
+    inline std::string applyFormat(const std::string &value, const std::string &spec, const std::string &locale = "C") {
+        if (spec.empty()) return value;
+
+        double numVal;
+
+        // Culture-specific: locale-aware number (n / N)
+        if (spec == "n" || spec == "N") {
+            return formatCultureNumber(value, locale);
+        }
+
+        // Culture-specific: date/time (d, D, t, T, f, F)
+        if (spec.size() == 1) {
+            char c = spec[0];
+            if (c == 'd' || c == 'D' || c == 't' || c == 'T' || c == 'f' || c == 'F') {
+                return formatCultureDateTime(value, c, locale);
+            }
+        }
+
+        // Fixed-point: .Nf (e.g. ".2f", ".4f")
+        if (spec.size() >= 2 && spec[0] == '.' && spec.back() == 'f') {
+            if (!tryParseDouble(value, numVal)) return value;
+            std::string digits = spec.substr(1, spec.size() - 2);
+            int precision = safeStoi(digits, 6);
+            if (precision > 50) precision = 50;
+            return snprintfDoublePrecision("%.*f", precision, numVal);
+        }
+
+        // Fixed-point shorthand: Nf (e.g. "2f", "4f")
+        if (spec.size() >= 2 && spec.back() == 'f' && std::isdigit(static_cast<unsigned char>(spec[0]))) {
+            if (!tryParseDouble(value, numVal)) return value;
+            int precision = safeStoi(spec.substr(0, spec.size() - 1), 6);
+            if (precision > 50) precision = 50;
+            return snprintfDoublePrecision("%.*f", precision, numVal);
+        }
+
+        // Currency: C or c
+        if (spec == "C" || spec == "c") {
+            if (!tryParseDouble(value, numVal)) return value;
+            if (numVal < 0) {
+                std::string formatted = snprintfDouble("%.2f", -numVal);
+                if (formatted == "0.00") return "$0.00";
+                return "-$" + formatted;
+            } else {
+                std::string formatted = snprintfDouble("%.2f", numVal);
+                return "$" + formatted;
+            }
+        }
+
+        // Hex: X (upper) or x (lower)
+        if (spec == "X" || spec == "x") {
+            if (!tryParseDouble(value, numVal)) return value;
+            char buf[64];
+            numVal = clampForLongLong(numVal);
+            long long intVal = static_cast<long long>(numVal);
+            unsigned long long uval;
+            std::string result;
+            if (intVal < 0) {
+                result = "-";
+                uval = 0ULL - static_cast<unsigned long long>(intVal);
+            } else {
+                uval = static_cast<unsigned long long>(intVal);
+            }
+            if (spec == "X") {
+                std::snprintf(buf, sizeof(buf), "%llX", uval);
+            } else {
+                std::snprintf(buf, sizeof(buf), "%llx", uval);
+            }
+            result += buf;
+            return result;
+        }
+
+        // Scientific: E (upper) or e (lower)
+        if (spec == "E" || spec == "e") {
+            if (!tryParseDouble(value, numVal)) return value;
+            char buf[64];
+            if (spec == "E") {
+                std::snprintf(buf, sizeof(buf), "%E", numVal);
+            } else {
+                std::snprintf(buf, sizeof(buf), "%e", numVal);
+            }
+            return std::string(buf);
+        }
+
+        // Percentage: P or p
+        if (spec == "P" || spec == "p") {
+            if (!tryParseDouble(value, numVal)) return value;
+            double pct = numVal * 100.0;
+            if (!std::isfinite(pct)) pct = numVal;
+            return snprintfDouble("%.2f", pct) + "%";
+        }
+
+        // Zero-padded integer: 0N (e.g. "04", "08")
+        if (spec.size() >= 2 && spec[0] == '0' && std::isdigit(static_cast<unsigned char>(spec[1]))) {
+            if (!tryParseDouble(value, numVal)) return value;
+            char buf[64];
+            numVal = clampForLongLong(numVal);
+            int width = safeStoi(spec.substr(1), 1);
+            if (width > 50) width = 50;
+            long long intVal = static_cast<long long>(numVal);
+            if (intVal < 0) {
+                unsigned long long absVal = 0ULL - static_cast<unsigned long long>(intVal);
+                std::snprintf(buf, sizeof(buf), "-%0*llu", width, absVal);
+            } else {
+                std::snprintf(buf, sizeof(buf), "%0*lld", width, intVal);
+            }
+            return std::string(buf);
+        }
+
+        // Unknown spec — return value as-is
+        return value;
+    }
+
+    // ----------------------------------------------------------------
+    // Shared placeholder iterator — single source of truth for
+    // operator stripping, validation, and name/spec splitting.
+    // ----------------------------------------------------------------
+
+    struct ParsedPlaceholder {
+        size_t startPos;
+        size_t endPos;
+        std::string name;
+        std::string fullContent;
+        std::string spec;
+        char op;  // '@', '$', or 0
+    };
+
+    template<typename Callback>
+    inline void forEachPlaceholder(const std::string &templateStr, Callback callback) {
+        for (size_t i = 0; i < templateStr.length(); ++i) {
+            if (templateStr[i] == '{') {
+                if (i + 1 < templateStr.length() && templateStr[i + 1] == '{') {
+                    ++i;
+                    continue;
+                }
+                size_t endPos = templateStr.find('}', i);
+                if (endPos == std::string::npos) break;
+                std::string content = templateStr.substr(i + 1, endPos - i - 1);
+                char op = 0;
+                std::string nameContent = content;
+                if (!content.empty() && (content[0] == '@' || content[0] == '$')) {
+                    op = content[0];
+                    nameContent = content.substr(1);
+                    if (nameContent.empty() || nameContent[0] == '@' || nameContent[0] == '$'
+                        || !(std::isalnum(static_cast<unsigned char>(nameContent[0])) || nameContent[0] == '_')) {
+                        i = endPos;
+                        continue;
+                    }
+                }
+                auto parts = splitPlaceholder(nameContent);
+                callback(ParsedPlaceholder{i, endPos, parts.first, content, parts.second, op});
+                i = endPos;
+            } else if (templateStr[i] == '}') {
+                if (i + 1 < templateStr.length() && templateStr[i + 1] == '}') {
+                    ++i;
+                }
+            }
+        }
+    }
+
+    // ----------------------------------------------------------------
+    // Shared template walker — single source of truth for the
+    // template-walk algorithm used by both reformatMessage and
+    // LunarLog::formatMessage.  Parameterized on placeholder type
+    // (works with ParsedPlaceholder and LunarLog::PlaceholderInfo;
+    // both expose startPos, endPos, spec).
+    // ----------------------------------------------------------------
+
+    template<typename PlaceholderType>
+    inline std::string walkTemplate(const std::string &templateStr,
+                                    const std::vector<PlaceholderType> &placeholders,
+                                    const std::vector<std::string> &values,
+                                    const std::string &locale) {
+        std::string result;
+        result.reserve(templateStr.length());
+        size_t phIdx = 0;
+        size_t pos = 0;
+
+        while (pos < templateStr.length()) {
+            if (phIdx < placeholders.size() && pos == placeholders[phIdx].startPos) {
+                if (phIdx < values.size()) {
+                    result += applyFormat(values[phIdx], placeholders[phIdx].spec, locale);
+                } else {
+                    result.append(templateStr, pos, placeholders[phIdx].endPos - pos + 1);
+                }
+                pos = placeholders[phIdx].endPos + 1;
+                ++phIdx;
+            } else if (templateStr[pos] == '{' && pos + 1 < templateStr.length() && templateStr[pos + 1] == '{') {
+                result += '{';
+                pos += 2;
+            } else if (templateStr[pos] == '}' && pos + 1 < templateStr.length() && templateStr[pos + 1] == '}') {
+                result += '}';
+                pos += 2;
+            } else {
+                size_t litStart = pos;
+                ++pos;
+                while (pos < templateStr.length()) {
+                    if (phIdx < placeholders.size() && pos == placeholders[phIdx].startPos) break;
+                    if (templateStr[pos] == '{' && pos + 1 < templateStr.length() && templateStr[pos + 1] == '{') break;
+                    if (templateStr[pos] == '}' && pos + 1 < templateStr.length() && templateStr[pos + 1] == '}') break;
+                    ++pos;
+                }
+                result.append(templateStr, litStart, pos - litStart);
+            }
+        }
+        return result;
+    }
+
+    // ----------------------------------------------------------------
+    // Message re-rendering with a different locale
+    // ----------------------------------------------------------------
+
+    inline std::string reformatMessage(const std::string &templateStr,
+                                       const std::vector<std::string> &values,
+                                       const std::string &locale) {
+        std::vector<ParsedPlaceholder> spans;
+        forEachPlaceholder(templateStr, [&](const ParsedPlaceholder& ph) {
+            spans.push_back(ph);
+        });
+        return walkTemplate(templateStr, spans, values, locale);
+    }
+
 } // namespace detail
 } // namespace minta
 

--- a/include/lunar_log/core/log_entry.hpp
+++ b/include/lunar_log/core/log_entry.hpp
@@ -29,18 +29,24 @@ namespace minta {
         std::string function;
         std::map<std::string, std::string> customContext;
         std::vector<PlaceholderProperty> properties;
+        /// The locale used when formatting this entry's message.
+        /// Formatters with a different per-sink locale can re-render
+        /// via detail::reformatMessage using the raw values in properties.
+        std::string locale;
 
         LogEntry(LogLevel level_, std::string message_, std::chrono::system_clock::time_point timestamp_,
                  std::string templateStr_, uint32_t templateHash_,
                  std::vector<std::pair<std::string, std::string>> arguments_,
                  std::string file_, int line_, std::string function_,
                  std::map<std::string, std::string> customContext_,
-                 std::vector<PlaceholderProperty> properties_)
+                 std::vector<PlaceholderProperty> properties_,
+                 std::string locale_ = "C")
             : level(level_), message(std::move(message_)), timestamp(timestamp_),
               templateStr(std::move(templateStr_)), templateHash(templateHash_),
               arguments(std::move(arguments_)),
               file(std::move(file_)), line(line_), function(std::move(function_)),
-              customContext(std::move(customContext_)), properties(std::move(properties_)) {}
+              customContext(std::move(customContext_)), properties(std::move(properties_)),
+              locale(std::move(locale_)) {}
     };
 } // namespace minta
 

--- a/include/lunar_log/formatter/formatter_interface.hpp
+++ b/include/lunar_log/formatter/formatter_interface.hpp
@@ -2,7 +2,10 @@
 #define LUNAR_LOG_FORMATTER_INTERFACE_HPP
 
 #include "../core/log_entry.hpp"
+#include "../core/log_common.hpp"
 #include <string>
+#include <vector>
+#include <mutex>
 
 namespace minta {
     class IFormatter {
@@ -10,6 +13,55 @@ namespace minta {
         virtual ~IFormatter() = default;
 
         virtual std::string format(const LogEntry &entry) const = 0;
+
+        /// Set the per-sink locale for culture-specific format specifiers.
+        /// When set (non-empty), the formatter re-renders the message using
+        /// this locale instead of the logger-level locale stored in the entry.
+        /// Thread-safe: can be called concurrently with format().
+        void setLocale(const std::string& locale) {
+            std::lock_guard<std::mutex> lock(m_localeMutex);
+            m_locale = locale;
+        }
+
+        std::string getLocale() const {
+            std::lock_guard<std::mutex> lock(m_localeMutex);
+            return m_locale;
+        }
+
+    protected:
+        /// Re-render the entry's message with this formatter's locale.
+        /// Returns the original message if no per-sink locale is set or
+        /// if the per-sink locale matches the entry's locale.
+        std::string localizedMessage(const LogEntry &entry) const {
+            // Copy locale under lock, then use the copy outside.
+            std::string localeCopy;
+            {
+                std::lock_guard<std::mutex> lock(m_localeMutex);
+                localeCopy = m_locale;
+            }
+            if (localeCopy.empty() || localeCopy == entry.locale) {
+                return entry.message;
+            }
+            // Textually-different locale names may resolve to the same
+            // locale (e.g. "en_US" vs "en_US.UTF-8") — skip re-render.
+            {
+                auto resolved1 = detail::tryCreateLocale(localeCopy);
+                auto resolved2 = detail::tryCreateLocale(entry.locale);
+                if (resolved1.name() == resolved2.name()) {
+                    return entry.message;
+                }
+            }
+            std::vector<std::string> values;
+            values.reserve(entry.properties.size());
+            for (const auto &prop : entry.properties) {
+                values.push_back(prop.value);
+            }
+            return detail::reformatMessage(entry.templateStr, values, localeCopy);
+        }
+
+    private:
+        mutable std::mutex m_localeMutex;
+        std::string m_locale;
     };
 } // namespace minta
 

--- a/include/lunar_log/formatter/human_readable_formatter.hpp
+++ b/include/lunar_log/formatter/human_readable_formatter.hpp
@@ -15,7 +15,7 @@ namespace minta {
             result += " [";
             result += getLevelString(entry.level);
             result += "] ";
-            result += entry.message;
+            result += localizedMessage(entry);
 
             if (!entry.file.empty()) {
                 result += " [";

--- a/include/lunar_log/formatter/json_formatter.hpp
+++ b/include/lunar_log/formatter/json_formatter.hpp
@@ -15,7 +15,7 @@ namespace minta {
         std::string format(const LogEntry &entry) const override {
             std::string levelStr = getLevelString(entry.level);
             std::string tsStr = detail::formatTimestamp(entry.timestamp);
-            std::string msgEsc = escapeJsonString(entry.message);
+            std::string msgEsc = escapeJsonString(localizedMessage(entry));
 
             std::string json;
             json.reserve(64 + levelStr.size() + tsStr.size() + msgEsc.size());

--- a/include/lunar_log/formatter/xml_formatter.hpp
+++ b/include/lunar_log/formatter/xml_formatter.hpp
@@ -19,7 +19,7 @@ namespace minta {
             xml += detail::formatTimestamp(entry.timestamp);
             xml += "</timestamp>";
             xml += "<message>";
-            xml += escapeXmlString(entry.message);
+            xml += escapeXmlString(localizedMessage(entry));
             xml += "</message>";
 
             if (!entry.templateStr.empty()) {

--- a/include/lunar_log/log_manager.hpp
+++ b/include/lunar_log/log_manager.hpp
@@ -95,6 +95,11 @@ namespace minta {
             m_sinks[index]->clearAllFilters();
         }
 
+        void setSinkLocale(size_t index, const std::string& locale) {
+            requireValidIndex(index);
+            m_sinks[index]->setLocale(locale);
+        }
+
     private:
         void requireValidIndex(size_t index) const {
             if (index >= m_sinks.size()) {

--- a/include/lunar_log/sink/sink_interface.hpp
+++ b/include/lunar_log/sink/sink_interface.hpp
@@ -75,6 +75,18 @@ namespace minta {
             m_hasFilters.store(false, std::memory_order_release);
         }
 
+        /// Set a per-sink locale for culture-specific formatting.
+        /// Forwards to the sink's formatter.
+        void setLocale(const std::string& locale) {
+            IFormatter* fmt = formatter();
+            if (fmt) fmt->setLocale(locale);
+        }
+
+        std::string getLocale() const {
+            IFormatter* fmt = formatter();
+            return fmt ? fmt->getLocale() : std::string();
+        }
+
         bool passesFilter(const LogEntry& entry) const {
             if (entry.level < m_minLevel.load(std::memory_order_relaxed)) {
                 return false;

--- a/test/tests/test_culture_formatting.cpp
+++ b/test/tests/test_culture_formatting.cpp
@@ -1,0 +1,776 @@
+#include <gtest/gtest.h>
+#include "lunar_log.hpp"
+#include "utils/test_utils.hpp"
+#include <thread>
+#include <atomic>
+#include <vector>
+#include <ctime>
+#include <locale>
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Check whether a locale name can be created via the same logic the library
+/// uses (name as-is, then name + ".UTF-8", then fallback to classic).
+static bool isLocaleAvailable(const std::string& name) {
+    try {
+        std::locale loc(name);
+        return true;
+    } catch (...) {}
+    if (name.find('.') == std::string::npos) {
+        try {
+            std::locale loc(name + ".UTF-8");
+            return true;
+        } catch (...) {}
+    }
+    return false;
+}
+
+// ---------------------------------------------------------------------------
+// Test fixture
+// ---------------------------------------------------------------------------
+
+class CultureFormattingTest : public ::testing::Test {
+protected:
+    void SetUp() override { TestUtils::cleanupLogFiles(); }
+    void TearDown() override { TestUtils::cleanupLogFiles(); }
+};
+
+// ===========================================================================
+// 1. Locale number formatting (:n, :N) with different locales
+// ===========================================================================
+
+TEST_F(CultureFormattingTest, NumberFormatWithCLocale) {
+    // With "C" locale (default), :n should produce the value unchanged
+    // (no thousand separators, '.' as decimal)
+    std::string result = minta::detail::applyFormat("1234567.89", "n", "C");
+    EXPECT_EQ(result, "1234567.89");
+}
+
+TEST_F(CultureFormattingTest, NumberFormatUpperN_CLocale) {
+    std::string result = minta::detail::applyFormat("1234567.89", "N", "C");
+    EXPECT_EQ(result, "1234567.89");
+}
+
+TEST_F(CultureFormattingTest, NumberFormatNonNumericPassthrough) {
+    // Non-numeric value should be returned as-is
+    std::string result = minta::detail::applyFormat("hello", "n", "de_DE");
+    EXPECT_EQ(result, "hello");
+}
+
+TEST_F(CultureFormattingTest, NumberFormatIntegerNoDecimals) {
+    // Integer values should not get spurious decimals
+    std::string result = minta::detail::applyFormat("42", "n", "C");
+    EXPECT_EQ(result, "42");
+}
+
+TEST_F(CultureFormattingTest, NumberFormatDE_DE) {
+    if (!isLocaleAvailable("de_DE")) {
+        GTEST_SKIP() << "de_DE locale not available on this system";
+    }
+    // German locale: decimal separator is ',' and thousand separator is '.'
+    std::string result = minta::detail::applyFormat("1234567.89", "n", "de_DE");
+    // Must contain the German decimal comma
+    EXPECT_NE(result.find(','), std::string::npos)
+        << "Expected German decimal comma in: " << result;
+    // Must contain the German thousand separator (period)
+    EXPECT_NE(result.find('.'), std::string::npos)
+        << "Expected German thousand separator in: " << result;
+}
+
+TEST_F(CultureFormattingTest, NumberFormatFR_FR) {
+    if (!isLocaleAvailable("fr_FR")) {
+        GTEST_SKIP() << "fr_FR locale not available on this system";
+    }
+    std::string result = minta::detail::applyFormat("1234567.89", "n", "fr_FR");
+    // French locale uses comma as decimal separator
+    EXPECT_NE(result.find(','), std::string::npos)
+        << "Expected French decimal comma in: " << result;
+}
+
+TEST_F(CultureFormattingTest, NumberFormatEN_US) {
+    if (!isLocaleAvailable("en_US")) {
+        GTEST_SKIP() << "en_US locale not available on this system";
+    }
+    std::string result = minta::detail::applyFormat("1234567.89", "n", "en_US");
+    // US locale uses '.' for decimal
+    EXPECT_NE(result.find('.'), std::string::npos)
+        << "Expected US decimal point in: " << result;
+    // US locale uses ',' for thousands
+    EXPECT_NE(result.find(','), std::string::npos)
+        << "Expected US thousand comma in: " << result;
+}
+
+TEST_F(CultureFormattingTest, NumberFormatThroughLogger) {
+    minta::LunarLog logger(minta::LogLevel::TRACE, false);
+    logger.addSink<minta::FileSink>("culture_number_test.txt");
+
+    // Default (no locale set) -> "C" behavior
+    logger.info("Value: {val:n}", 1234567.89);
+
+    logger.flush();
+    TestUtils::waitForFileContent("culture_number_test.txt");
+    std::string content = TestUtils::readLogFile("culture_number_test.txt");
+    EXPECT_NE(content.find("Value: 1234567.89"), std::string::npos)
+        << "Default locale should produce C-style number. Got: " << content;
+}
+
+TEST_F(CultureFormattingTest, NumberFormatWithLoggerLocale) {
+    if (!isLocaleAvailable("en_US")) {
+        GTEST_SKIP() << "en_US locale not available on this system";
+    }
+
+    minta::LunarLog logger(minta::LogLevel::TRACE, false);
+    logger.addSink<minta::FileSink>("culture_number_locale_test.txt");
+    logger.setLocale("en_US");
+
+    logger.info("Value: {val:n}", 1234567.89);
+
+    logger.flush();
+    TestUtils::waitForFileContent("culture_number_locale_test.txt");
+    std::string content = TestUtils::readLogFile("culture_number_locale_test.txt");
+    // en_US should produce thousand-separated number with commas
+    EXPECT_NE(content.find(','), std::string::npos)
+        << "en_US locale should add thousand separators. Got: " << content;
+}
+
+// ===========================================================================
+// 2. Date/time formatting (:d, :D, :t, :T, :f, :F) from unix timestamps
+// ===========================================================================
+
+// Use a known timestamp: 2024-01-15 10:30:45 UTC = 1705312245
+static const std::string kTestTimestamp = "1705312245";
+
+TEST_F(CultureFormattingTest, DateShortFormat) {
+    std::string result = minta::detail::applyFormat(kTestTimestamp, "d", "C");
+    // :d is short date (%x) - should produce something non-empty
+    EXPECT_FALSE(result.empty());
+    EXPECT_NE(result, kTestTimestamp) << "Date format should transform the timestamp";
+}
+
+TEST_F(CultureFormattingTest, DateLongFormat) {
+    std::string result = minta::detail::applyFormat(kTestTimestamp, "D", "C");
+    // :D is long date (%A, %B %d, %Y) - should contain year
+    EXPECT_FALSE(result.empty());
+    EXPECT_NE(result.find("2024"), std::string::npos)
+        << "Long date should contain year 2024. Got: " << result;
+    EXPECT_NE(result.find("January") != std::string::npos ||
+              result.find("Jan") != std::string::npos, false)
+        << "Long date should contain month. Got: " << result;
+}
+
+TEST_F(CultureFormattingTest, TimeShortFormat) {
+    std::string result = minta::detail::applyFormat(kTestTimestamp, "t", "C");
+    // :t is short time (%H:%M) - should contain a colon
+    EXPECT_FALSE(result.empty());
+    EXPECT_NE(result.find(':'), std::string::npos)
+        << "Short time should contain ':'. Got: " << result;
+}
+
+TEST_F(CultureFormattingTest, TimeLongFormat) {
+    std::string result = minta::detail::applyFormat(kTestTimestamp, "T", "C");
+    // :T is long time (%H:%M:%S) - should contain two colons
+    EXPECT_FALSE(result.empty());
+    size_t firstColon = result.find(':');
+    ASSERT_NE(firstColon, std::string::npos);
+    size_t secondColon = result.find(':', firstColon + 1);
+    EXPECT_NE(secondColon, std::string::npos)
+        << "Long time should contain HH:MM:SS. Got: " << result;
+}
+
+TEST_F(CultureFormattingTest, FullDateShortTime) {
+    std::string result = minta::detail::applyFormat(kTestTimestamp, "f", "C");
+    // :f is full date + short time - should contain year and colon
+    EXPECT_FALSE(result.empty());
+    EXPECT_NE(result.find("2024"), std::string::npos)
+        << "Full date+short time should contain year. Got: " << result;
+    EXPECT_NE(result.find(':'), std::string::npos)
+        << "Full date+short time should contain time. Got: " << result;
+}
+
+TEST_F(CultureFormattingTest, FullDateLongTime) {
+    std::string result = minta::detail::applyFormat(kTestTimestamp, "F", "C");
+    // :F is full date + long time
+    EXPECT_FALSE(result.empty());
+    EXPECT_NE(result.find("2024"), std::string::npos)
+        << "Full date+long time should contain year. Got: " << result;
+    size_t firstColon = result.find(':');
+    ASSERT_NE(firstColon, std::string::npos);
+    size_t secondColon = result.find(':', firstColon + 1);
+    EXPECT_NE(secondColon, std::string::npos)
+        << "Full date+long time should contain HH:MM:SS. Got: " << result;
+}
+
+TEST_F(CultureFormattingTest, DateTimeNonNumericPassthrough) {
+    // Non-numeric value should be returned as-is
+    std::string result = minta::detail::applyFormat("not-a-timestamp", "d", "C");
+    EXPECT_EQ(result, "not-a-timestamp");
+}
+
+TEST_F(CultureFormattingTest, DateTimeThroughLogger) {
+    minta::LunarLog logger(minta::LogLevel::TRACE, false);
+    logger.addSink<minta::FileSink>("culture_datetime_test.txt");
+
+    logger.info("Date: {ts:D}", 1705312245);
+
+    logger.flush();
+    TestUtils::waitForFileContent("culture_datetime_test.txt");
+    std::string content = TestUtils::readLogFile("culture_datetime_test.txt");
+    EXPECT_NE(content.find("2024"), std::string::npos)
+        << "Long date through logger should contain year. Got: " << content;
+}
+
+// ===========================================================================
+// 3. Default (no locale) behavior unchanged
+// ===========================================================================
+
+TEST_F(CultureFormattingTest, DefaultBehaviorFixedPoint) {
+    // Existing .2f spec must still work
+    std::string result = minta::detail::applyFormat("3.14159", ".2f", "C");
+    EXPECT_EQ(result, "3.14");
+}
+
+TEST_F(CultureFormattingTest, DefaultBehaviorCurrency) {
+    std::string result = minta::detail::applyFormat("42.5", "C", "C");
+    EXPECT_EQ(result, "$42.50");
+}
+
+TEST_F(CultureFormattingTest, DefaultBehaviorHex) {
+    std::string result = minta::detail::applyFormat("255", "X", "C");
+    EXPECT_EQ(result, "FF");
+}
+
+TEST_F(CultureFormattingTest, DefaultBehaviorPercentage) {
+    std::string result = minta::detail::applyFormat("0.856", "P", "C");
+    EXPECT_EQ(result, "85.60%");
+}
+
+TEST_F(CultureFormattingTest, DefaultBehaviorZeroPad) {
+    std::string result = minta::detail::applyFormat("42", "04", "C");
+    EXPECT_EQ(result, "0042");
+}
+
+TEST_F(CultureFormattingTest, DefaultBehaviorScientific) {
+    std::string result = minta::detail::applyFormat("1500", "e", "C");
+    EXPECT_NE(result.find("e+"), std::string::npos)
+        << "Scientific notation should contain 'e+'. Got: " << result;
+}
+
+TEST_F(CultureFormattingTest, DefaultBehaviorNoSpec) {
+    std::string result = minta::detail::applyFormat("hello", "", "C");
+    EXPECT_EQ(result, "hello");
+}
+
+TEST_F(CultureFormattingTest, DefaultBehaviorThroughLoggerUnchanged) {
+    // Logging with format specs that existed before culture support
+    // must produce the same results regardless of the new code
+    minta::LunarLog logger(minta::LogLevel::TRACE, false);
+    logger.addSink<minta::FileSink>("culture_default_test.txt");
+
+    logger.info("{a:.2f} {b:X} {c:C} {d:P} {e:04}", 3.14159, 255, 9.99, 0.5, 42);
+
+    logger.flush();
+    TestUtils::waitForFileContent("culture_default_test.txt");
+    std::string content = TestUtils::readLogFile("culture_default_test.txt");
+    EXPECT_NE(content.find("3.14 FF $9.99 50.00% 0042"), std::string::npos)
+        << "Existing format specs must be unchanged. Got: " << content;
+}
+
+// ===========================================================================
+// 4. Per-sink locale override
+// ===========================================================================
+
+TEST_F(CultureFormattingTest, PerSinkLocaleOverride) {
+    if (!isLocaleAvailable("en_US")) {
+        GTEST_SKIP() << "en_US locale not available on this system";
+    }
+
+    minta::LunarLog logger(minta::LogLevel::TRACE, false);
+    // Sink 0: default console sink is disabled (false); add two file sinks
+    logger.addSink<minta::FileSink>("culture_sink0_test.txt");  // sink 0
+    logger.addSink<minta::FileSink>("culture_sink1_test.txt");  // sink 1
+
+    // Logger locale is C (default). Override sink 1 to en_US.
+    logger.setSinkLocale(1, "en_US");
+
+    logger.info("Num: {val:n}", 1234567.89);
+
+    logger.flush();
+    TestUtils::waitForFileContent("culture_sink0_test.txt");
+    TestUtils::waitForFileContent("culture_sink1_test.txt");
+
+    std::string sink0 = TestUtils::readLogFile("culture_sink0_test.txt");
+    std::string sink1 = TestUtils::readLogFile("culture_sink1_test.txt");
+
+    // Sink 0 uses logger locale (C) -> no thousand separators
+    EXPECT_NE(sink0.find("Num: 1234567.89"), std::string::npos)
+        << "Sink 0 (C locale) should have plain number. Got: " << sink0;
+
+    // Sink 1 uses en_US -> should have thousand commas
+    EXPECT_NE(sink1.find(','), std::string::npos)
+        << "Sink 1 (en_US locale) should have thousand separators. Got: " << sink1;
+}
+
+TEST_F(CultureFormattingTest, PerSinkLocaleOverrideDateTime) {
+    minta::LunarLog logger(minta::LogLevel::TRACE, false);
+    logger.addSink<minta::FileSink>("culture_sinkdt0_test.txt");  // sink 0
+    logger.addSink<minta::FileSink>("culture_sinkdt1_test.txt");  // sink 1
+
+    // Both use C, but sink 1 is overridden. Even with C, the formatter
+    // must produce a re-rendered message via localizedMessage().
+    logger.setSinkLocale(1, "C");
+
+    logger.info("Time: {ts:T}", 1705312245);
+
+    logger.flush();
+    TestUtils::waitForFileContent("culture_sinkdt0_test.txt");
+    TestUtils::waitForFileContent("culture_sinkdt1_test.txt");
+
+    std::string sink0 = TestUtils::readLogFile("culture_sinkdt0_test.txt");
+    std::string sink1 = TestUtils::readLogFile("culture_sinkdt1_test.txt");
+
+    // Both should contain a colon (time format)
+    EXPECT_NE(sink0.find("Time:"), std::string::npos);
+    EXPECT_NE(sink1.find("Time:"), std::string::npos);
+}
+
+TEST_F(CultureFormattingTest, PerSinkLocaleJsonFormatter) {
+    if (!isLocaleAvailable("en_US")) {
+        GTEST_SKIP() << "en_US locale not available on this system";
+    }
+
+    minta::LunarLog logger(minta::LogLevel::TRACE, false);
+    logger.addSink<minta::FileSink, minta::JsonFormatter>("culture_json_test.txt");  // sink 0
+
+    logger.setSinkLocale(0, "en_US");
+
+    logger.info("Val: {v:n}", 1234567.89);
+
+    logger.flush();
+    TestUtils::waitForFileContent("culture_json_test.txt");
+    std::string content = TestUtils::readLogFile("culture_json_test.txt");
+
+    // JSON message should contain the en_US formatted number
+    EXPECT_NE(content.find("\"message\":"), std::string::npos);
+    // The formatted message inside JSON should have thousand separators
+    EXPECT_NE(content.find(','), std::string::npos)
+        << "JSON with en_US locale should show thousand separators. Got: " << content;
+}
+
+TEST_F(CultureFormattingTest, PerSinkLocaleXmlFormatter) {
+    if (!isLocaleAvailable("en_US")) {
+        GTEST_SKIP() << "en_US locale not available on this system";
+    }
+
+    minta::LunarLog logger(minta::LogLevel::TRACE, false);
+    logger.addSink<minta::FileSink, minta::XmlFormatter>("culture_xml_test.txt");  // sink 0
+
+    logger.setSinkLocale(0, "en_US");
+
+    logger.info("Val: {v:n}", 1234567.89);
+
+    logger.flush();
+    TestUtils::waitForFileContent("culture_xml_test.txt");
+    std::string content = TestUtils::readLogFile("culture_xml_test.txt");
+
+    EXPECT_NE(content.find("<message>"), std::string::npos);
+    EXPECT_NE(content.find(','), std::string::npos)
+        << "XML with en_US locale should show thousand separators. Got: " << content;
+}
+
+// ===========================================================================
+// 5. Thread-safe locale changes
+// ===========================================================================
+
+TEST_F(CultureFormattingTest, ThreadSafeLocaleChange) {
+    minta::LunarLog logger(minta::LogLevel::TRACE, false);
+    logger.addSink<minta::FileSink>("culture_thread_test.txt");
+
+    std::atomic<bool> stop(false);
+    const int kIterations = 200;
+
+    // Thread that flips locale back and forth
+    std::thread localeChanger([&] {
+        for (int i = 0; i < kIterations && !stop; ++i) {
+            logger.setLocale(i % 2 == 0 ? "C" : "en_US");
+        }
+    });
+
+    // Thread that logs concurrently
+    std::thread logWriter([&] {
+        for (int i = 0; i < kIterations && !stop; ++i) {
+            logger.info("Count: {n:n}", i);
+        }
+    });
+
+    localeChanger.join();
+    logWriter.join();
+
+    logger.flush();
+    TestUtils::waitForFileContent("culture_thread_test.txt");
+    std::string content = TestUtils::readLogFile("culture_thread_test.txt");
+
+    // Verify we got output without crashes — the key goal is no data races
+    EXPECT_NE(content.find("Count:"), std::string::npos)
+        << "Concurrent locale changes should not crash or lose messages";
+}
+
+TEST_F(CultureFormattingTest, GetLocaleMatchesSetLocale) {
+    minta::LunarLog logger(minta::LogLevel::TRACE, false);
+    EXPECT_EQ(logger.getLocale(), "C");
+
+    logger.setLocale("de_DE");
+    EXPECT_EQ(logger.getLocale(), "de_DE");
+
+    logger.setLocale("C");
+    EXPECT_EQ(logger.getLocale(), "C");
+}
+
+// ===========================================================================
+// 6. Invalid locale fallback to C
+// ===========================================================================
+
+TEST_F(CultureFormattingTest, InvalidLocaleFallbackNumber) {
+    // A completely bogus locale should fall back to C behavior
+    std::string result = minta::detail::applyFormat("1234.56", "n", "xx_BOGUS_LOCALE_99");
+    // Should not crash, should produce a reasonable result
+    EXPECT_FALSE(result.empty());
+    // Fallback to classic locale -> no thousand separators, '.' decimal
+    EXPECT_EQ(result, "1234.56");
+}
+
+TEST_F(CultureFormattingTest, InvalidLocaleFallbackDateTime) {
+    std::string result = minta::detail::applyFormat(kTestTimestamp, "D", "xx_BOGUS_LOCALE_99");
+    // Should not crash, should produce a date string
+    EXPECT_FALSE(result.empty());
+    EXPECT_NE(result, kTestTimestamp) << "Should still format as date with fallback locale";
+}
+
+TEST_F(CultureFormattingTest, EmptyLocaleFallback) {
+    std::string result = minta::detail::applyFormat("1234.56", "n", "");
+    EXPECT_EQ(result, "1234.56");
+}
+
+TEST_F(CultureFormattingTest, POSIXLocaleFallback) {
+    std::string result = minta::detail::applyFormat("1234.56", "n", "POSIX");
+    EXPECT_EQ(result, "1234.56");
+}
+
+TEST_F(CultureFormattingTest, InvalidLocaleThroughLogger) {
+    minta::LunarLog logger(minta::LogLevel::TRACE, false);
+    logger.addSink<minta::FileSink>("culture_invalid_test.txt");
+    logger.setLocale("completely_invalid_locale_xyz");
+
+    logger.info("Num: {val:n}", 9876.54);
+
+    logger.flush();
+    TestUtils::waitForFileContent("culture_invalid_test.txt");
+    std::string content = TestUtils::readLogFile("culture_invalid_test.txt");
+    // Should fall back to C and not crash
+    EXPECT_NE(content.find("Num: 9876.54"), std::string::npos)
+        << "Invalid locale should fall back to C formatting. Got: " << content;
+}
+
+// ===========================================================================
+// 7. Edge cases and detail:: function tests
+// ===========================================================================
+
+TEST_F(CultureFormattingTest, TryCreateLocaleClassicNames) {
+    std::locale loc1 = minta::detail::tryCreateLocale("C");
+    EXPECT_EQ(loc1.name(), std::locale::classic().name());
+
+    std::locale loc2 = minta::detail::tryCreateLocale("POSIX");
+    EXPECT_EQ(loc2.name(), std::locale::classic().name());
+
+    std::locale loc3 = minta::detail::tryCreateLocale("");
+    EXPECT_EQ(loc3.name(), std::locale::classic().name());
+}
+
+TEST_F(CultureFormattingTest, TryCreateLocaleInvalid) {
+    std::locale loc = minta::detail::tryCreateLocale("not_a_real_locale_abc");
+    EXPECT_EQ(loc.name(), std::locale::classic().name());
+}
+
+TEST_F(CultureFormattingTest, FormatCultureNumberNegative) {
+    std::string result = minta::detail::formatCultureNumber("-1234.56", "C");
+    EXPECT_EQ(result, "-1234.56");
+}
+
+TEST_F(CultureFormattingTest, FormatCultureNumberZero) {
+    std::string result = minta::detail::formatCultureNumber("0", "C");
+    EXPECT_EQ(result, "0");
+}
+
+TEST_F(CultureFormattingTest, FormatCultureNumberLargePrecision) {
+    // Value with many decimal places — precision capped at 15
+    std::string result = minta::detail::formatCultureNumber("1.123456789012345678", "C");
+    EXPECT_FALSE(result.empty());
+}
+
+TEST_F(CultureFormattingTest, FormatCultureDateTimeEpoch) {
+    // Epoch: Jan 1, 1970
+    std::string result = minta::detail::formatCultureDateTime("0", 'D', "C");
+    EXPECT_FALSE(result.empty());
+    EXPECT_NE(result.find("1970"), std::string::npos)
+        << "Epoch should format to 1970. Got: " << result;
+}
+
+TEST_F(CultureFormattingTest, FormatCultureDateTimeInvalidSpec) {
+    // Invalid spec character should return value as-is
+    std::string result = minta::detail::formatCultureDateTime("12345", 'z', "C");
+    EXPECT_EQ(result, "12345");
+}
+
+TEST_F(CultureFormattingTest, ReformatMessageBasic) {
+    // Test detail::reformatMessage directly
+    std::vector<std::string> values = {"1234.56"};
+    std::string result = minta::detail::reformatMessage("Val: {x:n}", values, "C");
+    EXPECT_EQ(result, "Val: 1234.56");
+}
+
+TEST_F(CultureFormattingTest, ReformatMessageEscapedBraces) {
+    std::vector<std::string> values = {"42"};
+    std::string result = minta::detail::reformatMessage("{{literal}} {x:n}", values, "C");
+    EXPECT_EQ(result, "{literal} 42");
+}
+
+TEST_F(CultureFormattingTest, ReformatMessageMultiplePlaceholders) {
+    std::vector<std::string> values = {"100", "200"};
+    std::string result = minta::detail::reformatMessage("{a:n} and {b:n}", values, "C");
+    EXPECT_EQ(result, "100 and 200");
+}
+
+TEST_F(CultureFormattingTest, ReformatMessageWithOperator) {
+    std::vector<std::string> values = {"42"};
+    std::string result = minta::detail::reformatMessage("Val: {@x:n}", values, "C");
+    EXPECT_EQ(result, "Val: 42");
+}
+
+TEST_F(CultureFormattingTest, LocalizedMessageSameLocaleNoRerender) {
+    minta::LunarLog logger(minta::LogLevel::TRACE, false);
+    logger.addSink<minta::FileSink>("culture_same_locale_test.txt");
+    logger.info("Price: {v:C}", 9.99);
+
+    logger.flush();
+    TestUtils::waitForFileContent("culture_same_locale_test.txt");
+    std::string content = TestUtils::readLogFile("culture_same_locale_test.txt");
+    EXPECT_NE(content.find("Price: $9.99"), std::string::npos)
+        << "Same-locale should produce original message. Got: " << content;
+}
+
+// ===========================================================================
+// 8. R1 review — additional test coverage
+// ===========================================================================
+
+TEST_F(CultureFormattingTest, ConcurrentSetSinkLocaleAndLogging) {
+    if (!isLocaleAvailable("en_US")) {
+        GTEST_SKIP() << "en_US locale not available on this system";
+    }
+
+    minta::LunarLog logger(minta::LogLevel::TRACE, false);
+    logger.addSink<minta::FileSink>("culture_conc_sink_test.txt");
+
+    std::atomic<bool> stop(false);
+    const int kIterations = 300;
+
+    std::thread sinkLocaleChanger([&] {
+        for (int i = 0; i < kIterations && !stop; ++i) {
+            logger.setSinkLocale(0, i % 2 == 0 ? "C" : "en_US");
+        }
+    });
+
+    std::thread logWriter([&] {
+        for (int i = 0; i < kIterations && !stop; ++i) {
+            logger.info("Val: {n:n}", 1234567.89);
+        }
+    });
+
+    sinkLocaleChanger.join();
+    logWriter.join();
+
+    logger.flush();
+    TestUtils::waitForFileContent("culture_conc_sink_test.txt");
+    std::string content = TestUtils::readLogFile("culture_conc_sink_test.txt");
+    EXPECT_NE(content.find("Val:"), std::string::npos)
+        << "Concurrent setSinkLocale + logging must not crash";
+}
+
+TEST_F(CultureFormattingTest, LocaleChangeBetweenMessages) {
+    if (!isLocaleAvailable("en_US") || !isLocaleAvailable("de_DE")) {
+        GTEST_SKIP() << "en_US and de_DE locales required";
+    }
+
+    minta::LunarLog logger(minta::LogLevel::TRACE, false);
+    logger.addSink<minta::FileSink>("culture_locale_change_test.txt");
+
+    logger.setLocale("en_US");
+    logger.info("A: {v:n}", 1234567.89);
+    logger.flush();
+
+    logger.setLocale("de_DE");
+    logger.info("B: {v:n}", 1234567.89);
+    logger.flush();
+
+    TestUtils::waitForFileContent("culture_locale_change_test.txt");
+    std::string content = TestUtils::readLogFile("culture_locale_change_test.txt");
+
+    size_t posA = content.find("A: ");
+    size_t posB = content.find("B: ");
+    ASSERT_NE(posA, std::string::npos);
+    ASSERT_NE(posB, std::string::npos);
+
+    std::string lineA = content.substr(posA, content.find('\n', posA) - posA);
+    std::string lineB = content.substr(posB, content.find('\n', posB) - posB);
+
+    EXPECT_NE(lineA, lineB)
+        << "en_US and de_DE should produce different formatting. A=" << lineA << " B=" << lineB;
+}
+
+TEST_F(CultureFormattingTest, MixedSpecifiersSameTemplate) {
+    if (!isLocaleAvailable("en_US")) {
+        GTEST_SKIP() << "en_US locale not available on this system";
+    }
+
+    minta::LunarLog logger(minta::LogLevel::TRACE, false);
+    logger.addSink<minta::FileSink>("culture_mixed_spec_test.txt");
+    logger.setLocale("en_US");
+
+    logger.info("{a:n} and {b:.2f}", 1234567.89, 3.14159);
+
+    logger.flush();
+    TestUtils::waitForFileContent("culture_mixed_spec_test.txt");
+    std::string content = TestUtils::readLogFile("culture_mixed_spec_test.txt");
+
+    EXPECT_NE(content.find(","), std::string::npos)
+        << ":n with en_US should have thousand separator. Got: " << content;
+    EXPECT_NE(content.find("3.14"), std::string::npos)
+        << ":.2f should still work alongside :n. Got: " << content;
+}
+
+TEST_F(CultureFormattingTest, VeryLargeNumbersWithN) {
+    std::string r1 = minta::detail::applyFormat("1000000000000000", "n", "C");
+    EXPECT_FALSE(r1.empty());
+    EXPECT_NE(r1.find("1"), std::string::npos);
+
+    std::string r2 = minta::detail::applyFormat("100000000000000000000", "n", "C");
+    EXPECT_FALSE(r2.empty());
+
+    if (isLocaleAvailable("en_US")) {
+        std::string r3 = minta::detail::applyFormat("1000000000000000", "n", "en_US");
+        EXPECT_NE(r3.find(","), std::string::npos)
+            << "1e15 with en_US should have separators. Got: " << r3;
+
+        std::string r4 = minta::detail::applyFormat("100000000000000000000", "n", "en_US");
+        EXPECT_FALSE(r4.empty())
+            << "1e20 should not crash. Got: " << r4;
+    }
+}
+
+TEST_F(CultureFormattingTest, MultipleDifferentPerSinkLocales) {
+    bool hasDE = isLocaleAvailable("de_DE");
+    bool hasEN = isLocaleAvailable("en_US");
+    bool hasFR = isLocaleAvailable("fr_FR");
+    if (!hasDE || !hasEN || !hasFR) {
+        GTEST_SKIP() << "de_DE, en_US, and fr_FR locales all required";
+    }
+
+    minta::LunarLog logger(minta::LogLevel::TRACE, false);
+    logger.addSink<minta::FileSink>("culture_multi0_test.txt");
+    logger.addSink<minta::FileSink>("culture_multi1_test.txt");
+    logger.addSink<minta::FileSink>("culture_multi2_test.txt");
+
+    logger.setSinkLocale(0, "de_DE");
+    logger.setSinkLocale(1, "en_US");
+    logger.setSinkLocale(2, "fr_FR");
+
+    logger.info("Num: {v:n}", 1234567.89);
+    logger.flush();
+
+    TestUtils::waitForFileContent("culture_multi0_test.txt");
+    TestUtils::waitForFileContent("culture_multi1_test.txt");
+    TestUtils::waitForFileContent("culture_multi2_test.txt");
+
+    std::string s0 = TestUtils::readLogFile("culture_multi0_test.txt");
+    std::string s1 = TestUtils::readLogFile("culture_multi1_test.txt");
+    std::string s2 = TestUtils::readLogFile("culture_multi2_test.txt");
+
+    EXPECT_NE(s0.find("Num:"), std::string::npos);
+    EXPECT_NE(s1.find("Num:"), std::string::npos);
+    EXPECT_NE(s2.find("Num:"), std::string::npos);
+
+    size_t numStart0 = s0.find("Num: ") + 5;
+    size_t numStart1 = s1.find("Num: ") + 5;
+    std::string num0 = s0.substr(numStart0, s0.find('\n', numStart0) - numStart0);
+    std::string num1 = s1.substr(numStart1, s1.find('\n', numStart1) - numStart1);
+    EXPECT_NE(num0, num1)
+        << "de_DE and en_US should differ. de=" << num0 << " en=" << num1;
+}
+
+TEST_F(CultureFormattingTest, NumberFormatScientificNotationInput) {
+    // Direct test of the sci-notation precision guard:
+    // when the value string itself contains scientific notation,
+    // formatCultureNumber detects 'e'/'E' and uses fixed precision.
+    std::string result = minta::detail::formatCultureNumber("1.5e+03", "C");
+    EXPECT_FALSE(result.empty());
+    EXPECT_NE(result.find("1500"), std::string::npos)
+        << "1.5e+03 should format as fixed-point containing 1500. Got: " << result;
+    EXPECT_EQ(result.find('e'), std::string::npos)
+        << "Sci-notation should be converted to fixed-point. Got: " << result;
+}
+
+TEST_F(CultureFormattingTest, NumberFormatDoubleProducingScientificNotation) {
+    // Test with actual double values large enough that toString(double)
+    // renders in scientific notation via %.15g, exercising the guard
+    // through the full logger pipeline.
+    minta::LunarLog logger(minta::LogLevel::TRACE, false);
+    logger.addSink<minta::FileSink>("culture_sci_double_test.txt");
+
+    logger.info("Big: {val:n}", 1.5e+20);
+
+    logger.flush();
+    TestUtils::waitForFileContent("culture_sci_double_test.txt");
+    std::string content = TestUtils::readLogFile("culture_sci_double_test.txt");
+
+    EXPECT_NE(content.find("Big:"), std::string::npos)
+        << "Sci-notation double with :n should produce output. Got: " << content;
+    // The sci-notation guard converts to fixed-point, so no 'e+' in output
+    size_t bigPos = content.find("Big: ");
+    ASSERT_NE(bigPos, std::string::npos);
+    std::string numPart = content.substr(bigPos + 5, content.find('\n', bigPos) - bigPos - 5);
+    EXPECT_EQ(numPart.find("e+"), std::string::npos)
+        << "Sci-notation should be converted to fixed-point by :n. Got: " << numPart;
+}
+
+TEST_F(CultureFormattingTest, ResetPerSinkLocaleRevertsToEntryLocale) {
+    if (!isLocaleAvailable("en_US")) {
+        GTEST_SKIP() << "en_US locale not available on this system";
+    }
+
+    minta::LunarLog logger(minta::LogLevel::TRACE, false);
+    logger.addSink<minta::FileSink>("culture_reset_test.txt");
+
+    logger.setSinkLocale(0, "en_US");
+    logger.info("Before: {v:n}", 1234567.89);
+    logger.flush();
+
+    logger.setSinkLocale(0, "");
+    logger.info("After: {v:n}", 1234567.89);
+    logger.flush();
+
+    TestUtils::waitForFileContent("culture_reset_test.txt");
+    std::string content = TestUtils::readLogFile("culture_reset_test.txt");
+
+    size_t posBefore = content.find("Before: ");
+    size_t posAfter = content.find("After: ");
+    ASSERT_NE(posBefore, std::string::npos);
+    ASSERT_NE(posAfter, std::string::npos);
+
+    std::string lineBefore = content.substr(posBefore, content.find('\n', posBefore) - posBefore);
+    std::string lineAfter = content.substr(posAfter, content.find('\n', posAfter) - posAfter);
+
+    EXPECT_NE(lineBefore.find(","), std::string::npos)
+        << "Before reset: en_US should have commas. Got: " << lineBefore;
+    EXPECT_EQ(lineAfter.find(","), std::string::npos)
+        << "After reset to '': should revert to entry locale (C). Got: " << lineAfter;
+}

--- a/test/tests/utils/test_utils.cpp
+++ b/test/tests/utils/test_utils.cpp
@@ -51,7 +51,18 @@ void TestUtils::cleanupLogFiles() {
         "template_json_test.txt", "template_xml_test.txt",
         "template_validation_test.txt", "template_cache_test.txt",
         "template_concurrent_test.txt", "template_eviction_test.txt",
-        "template_resize_test.txt", "template_opcache_test.txt"
+        "template_resize_test.txt", "template_opcache_test.txt",
+        "culture_number_test.txt", "culture_number_locale_test.txt",
+        "culture_datetime_test.txt", "culture_default_test.txt",
+        "culture_sink0_test.txt", "culture_sink1_test.txt",
+        "culture_sinkdt0_test.txt", "culture_sinkdt1_test.txt",
+        "culture_json_test.txt", "culture_xml_test.txt",
+        "culture_thread_test.txt", "culture_invalid_test.txt",
+        "culture_same_locale_test.txt",
+        "culture_conc_sink_test.txt", "culture_locale_change_test.txt",
+        "culture_mixed_spec_test.txt",
+        "culture_multi0_test.txt", "culture_multi1_test.txt", "culture_multi2_test.txt",
+        "culture_reset_test.txt"
     };
 
     for (const auto &filename : filesToRemove) {


### PR DESCRIPTION
Locale-aware formatting support for log placeholders.

## What's new

- **Number formatting** — `:n` / `:N` specs respect locale decimal/thousand separators (e.g. `1.234,56` in de_DE)
- **Date/time formatting** — `:d` `:D` `:t` `:T` `:f` `:F` specs format unix timestamps with locale month/day names
- **Per-sink locale** — different sinks can format in different locales independently
- **Global locale** — `setLocale()` sets the default for all log entries
- Thread-safe locale access with atomic fast-path (zero overhead when unused)
- `thread_local` locale cache for multi-sink setups
- Shared template walker (`walkTemplate`) eliminates parser duplication

## API

```cpp
logger->setLocale("de_DE");
logger->info("Price: {amount:n}", "amount", 1234.56);
// Output: Price: 1.234,56

logger->info("Created: {ts:f}", "ts", 1700000000);
// Output: Created: 11/14/2023 10:13:20 PM
```

## Tests

253 tests passing across gcc/clang/MSVC, C++11/14/17.

Closes #3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added culture-specific formatting for numbers and dates/times with locale awareness
  * Introduced per-sink locale configuration for independent formatting across different sinks
  * Added logger-wide and per-sink locale management with thread-safe operations

* **Documentation**
  * Added culture-specific formatting guide with usage examples and compatibility details
  * Included thread-safety documentation for locale operations
  * Added migration notes for format specifier changes

* **Tests**
  * Added comprehensive test suite for locale-aware formatting across multiple scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->