### PR TITLE
Implement named sinks and tag-based routing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@
 /build/
 
 .idea/
+build11/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,6 +101,8 @@ if(LUNARLOG_BUILD_TESTS)
             test/tests/test_template_handling.cpp
             test/tests/test_filtering.cpp
             test/tests/test_culture_formatting.cpp
+            test/tests/test_named_sinks.cpp
+            test/tests/test_tag_routing.cpp
             test/tests/utils/test_utils.cpp
     )
 

--- a/include/lunar_log/core/log_entry.hpp
+++ b/include/lunar_log/core/log_entry.hpp
@@ -29,6 +29,8 @@ namespace minta {
         std::string function;
         std::map<std::string, std::string> customContext;
         std::vector<PlaceholderProperty> properties;
+        /// Tags parsed from [bracketed] prefixes in the message template.
+        std::vector<std::string> tags;
         /// The locale used when formatting this entry's message.
         /// Formatters with a different per-sink locale can re-render
         /// via detail::reformatMessage using the raw values in properties.
@@ -40,12 +42,14 @@ namespace minta {
                  std::string file_, int line_, std::string function_,
                  std::map<std::string, std::string> customContext_,
                  std::vector<PlaceholderProperty> properties_,
+                 std::vector<std::string> tags_ = {},
                  std::string locale_ = "C")
             : level(level_), message(std::move(message_)), timestamp(timestamp_),
               templateStr(std::move(templateStr_)), templateHash(templateHash_),
               arguments(std::move(arguments_)),
               file(std::move(file_)), line(line_), function(std::move(function_)),
               customContext(std::move(customContext_)), properties(std::move(properties_)),
+              tags(std::move(tags_)),
               locale(std::move(locale_)) {}
     };
 } // namespace minta

--- a/include/lunar_log/formatter/json_formatter.hpp
+++ b/include/lunar_log/formatter/json_formatter.hpp
@@ -62,6 +62,19 @@ namespace minta {
                 json += '}';
             }
 
+            if (!entry.tags.empty()) {
+                json += R"(,"tags":[)";
+                bool first = true;
+                for (const auto &tag : entry.tags) {
+                    if (!first) json += ',';
+                    json += '"';
+                    json += escapeJsonString(tag);
+                    json += '"';
+                    first = false;
+                }
+                json += ']';
+            }
+
             if (!entry.properties.empty()) {
                 json += R"(,"properties":{)";
                 bool first = true;

--- a/include/lunar_log/formatter/xml_formatter.hpp
+++ b/include/lunar_log/formatter/xml_formatter.hpp
@@ -42,6 +42,16 @@ namespace minta {
                 xml += "</function>";
             }
 
+            if (!entry.tags.empty()) {
+                xml += "<tags>";
+                for (const auto &tag : entry.tags) {
+                    xml += "<tag>";
+                    xml += escapeXmlString(tag);
+                    xml += "</tag>";
+                }
+                xml += "</tags>";
+            }
+
             if (!entry.customContext.empty()) {
                 xml += "<context>";
                 for (const auto &ctx : entry.customContext) {

--- a/test/tests/test_named_sinks.cpp
+++ b/test/tests/test_named_sinks.cpp
@@ -1,0 +1,328 @@
+#include <gtest/gtest.h>
+#include "lunar_log.hpp"
+#include "utils/test_utils.hpp"
+#include <stdexcept>
+
+class NamedSinksTest : public ::testing::Test {
+protected:
+    void SetUp() override { TestUtils::cleanupLogFiles(); }
+    void TearDown() override { TestUtils::cleanupLogFiles(); }
+};
+
+TEST_F(NamedSinksTest, AddNamedSinkBasic) {
+    minta::LunarLog logger(minta::LogLevel::INFO, false);
+    logger.addSink<minta::FileSink>("myfile", "test_named1.txt");
+    logger.info("Hello named sink");
+    logger.flush();
+    TestUtils::waitForFileContent("test_named1.txt");
+    std::string content = TestUtils::readLogFile("test_named1.txt");
+    EXPECT_TRUE(content.find("Hello named sink") != std::string::npos);
+}
+
+TEST_F(NamedSinksTest, DuplicateNameThrows) {
+    minta::LunarLog logger(minta::LogLevel::INFO, false);
+    logger.addSink<minta::FileSink>("dup", "test_dup1.txt");
+    EXPECT_THROW(logger.addSink<minta::FileSink>("dup", "test_dup2.txt"), std::invalid_argument);
+}
+
+TEST_F(NamedSinksTest, UnknownNameThrows) {
+    minta::LunarLog logger(minta::LogLevel::INFO, false);
+    EXPECT_THROW(logger.sink("nonexistent"), std::invalid_argument);
+}
+
+TEST_F(NamedSinksTest, SinkProxySetLevel) {
+    minta::LunarLog logger(minta::LogLevel::TRACE, false);
+    logger.addSink<minta::FileSink>("errors", "test_errors.txt");
+    logger.sink("errors").level(minta::LogLevel::ERROR);
+    logger.info("Should not appear");
+    logger.error("Should appear");
+    logger.flush();
+    TestUtils::waitForFileContent("test_errors.txt");
+    std::string content = TestUtils::readLogFile("test_errors.txt");
+    EXPECT_TRUE(content.find("Should not appear") == std::string::npos);
+    EXPECT_TRUE(content.find("Should appear") != std::string::npos);
+}
+
+TEST_F(NamedSinksTest, SinkProxyChaining) {
+    minta::LunarLog logger(minta::LogLevel::TRACE, false);
+    logger.addSink<minta::FileSink>("chained", "test_chained.txt");
+    logger.sink("chained").level(minta::LogLevel::WARN);
+    logger.debug("Debug msg");
+    logger.warn("Warn msg");
+    logger.flush();
+    TestUtils::waitForFileContent("test_chained.txt");
+    std::string content = TestUtils::readLogFile("test_chained.txt");
+    EXPECT_TRUE(content.find("Debug msg") == std::string::npos);
+    EXPECT_TRUE(content.find("Warn msg") != std::string::npos);
+}
+
+TEST_F(NamedSinksTest, AutoNamedSinks) {
+    minta::LunarLog logger(minta::LogLevel::INFO, false);
+    logger.addSink<minta::FileSink>("test_auto0.txt");
+    // First unnamed sink gets auto-name "sink_0"
+    logger.sink("sink_0").level(minta::LogLevel::ERROR);
+    logger.info("Should not appear");
+    logger.error("Error appears");
+    logger.flush();
+    TestUtils::waitForFileContent("test_auto0.txt");
+    std::string content = TestUtils::readLogFile("test_auto0.txt");
+    EXPECT_TRUE(content.find("Should not appear") == std::string::npos);
+    EXPECT_TRUE(content.find("Error appears") != std::string::npos);
+}
+
+TEST_F(NamedSinksTest, NamedSinkWithFormatter) {
+    minta::LunarLog logger(minta::LogLevel::INFO, false);
+    logger.addSink<minta::FileSink, minta::JsonFormatter>("jsonfile", "test_named_json.txt");
+    logger.info("JSON named {val}", 42);
+    logger.flush();
+    TestUtils::waitForFileContent("test_named_json.txt");
+    std::string content = TestUtils::readLogFile("test_named_json.txt");
+    EXPECT_TRUE(content.find("\"level\":\"INFO\"") != std::string::npos);
+    EXPECT_TRUE(content.find("JSON named 42") != std::string::npos);
+}
+
+TEST_F(NamedSinksTest, MultipleNamedSinks) {
+    minta::LunarLog logger(minta::LogLevel::TRACE, false);
+    logger.addSink<minta::FileSink>("all", "test_all.txt");
+    logger.addSink<minta::FileSink>("errors", "test_err_only.txt");
+    logger.sink("errors").level(minta::LogLevel::ERROR);
+    logger.info("Info message");
+    logger.error("Error message");
+    logger.flush();
+    TestUtils::waitForFileContent("test_all.txt");
+    TestUtils::waitForFileContent("test_err_only.txt");
+    std::string allContent = TestUtils::readLogFile("test_all.txt");
+    std::string errContent = TestUtils::readLogFile("test_err_only.txt");
+    EXPECT_TRUE(allContent.find("Info message") != std::string::npos);
+    EXPECT_TRUE(allContent.find("Error message") != std::string::npos);
+    EXPECT_TRUE(errContent.find("Info message") == std::string::npos);
+    EXPECT_TRUE(errContent.find("Error message") != std::string::npos);
+}
+
+TEST_F(NamedSinksTest, IndexBasedApiStillWorks) {
+    minta::LunarLog logger(minta::LogLevel::TRACE, false);
+    logger.addSink<minta::FileSink>("test_idx.txt");
+    logger.setSinkLevel(0, minta::LogLevel::WARN);
+    logger.info("Should not appear");
+    logger.warn("Should appear");
+    logger.flush();
+    TestUtils::waitForFileContent("test_idx.txt");
+    std::string content = TestUtils::readLogFile("test_idx.txt");
+    EXPECT_TRUE(content.find("Should not appear") == std::string::npos);
+    EXPECT_TRUE(content.find("Should appear") != std::string::npos);
+}
+
+TEST_F(NamedSinksTest, SinkProxyFilterRule) {
+    minta::LunarLog logger(minta::LogLevel::TRACE, false);
+    logger.addSink<minta::FileSink>("filtered", "test_filtered.txt");
+    logger.sink("filtered").filterRule("level >= WARN");
+    logger.debug("Debug should be filtered");
+    logger.warn("Warn should pass");
+    logger.flush();
+    TestUtils::waitForFileContent("test_filtered.txt");
+    std::string content = TestUtils::readLogFile("test_filtered.txt");
+    EXPECT_TRUE(content.find("Debug should be filtered") == std::string::npos);
+    EXPECT_TRUE(content.find("Warn should pass") != std::string::npos);
+}
+
+TEST_F(NamedSinksTest, ClearFiltersOnProxy) {
+    minta::LunarLog logger(minta::LogLevel::TRACE, false);
+    logger.addSink<minta::FileSink>("clr", "test_clr.txt");
+    logger.sink("clr").only("metrics");
+    logger.sink("clr").clearTagFilters();
+    // After clearTagFilters, tag filters are cleared so untagged msgs should pass
+    logger.info("Info after clear");
+    logger.flush();
+    TestUtils::waitForFileContent("test_clr.txt");
+    std::string content = TestUtils::readLogFile("test_clr.txt");
+    EXPECT_TRUE(content.find("Info after clear") != std::string::npos);
+}
+
+TEST_F(NamedSinksTest, DefaultConsoleSinkAutoNamed) {
+    // Default console sink should be auto-named sink_0
+    minta::LunarLog logger(minta::LogLevel::INFO, true);
+    // Should not throw — default sink exists as sink_0
+    logger.sink("sink_0").level(minta::LogLevel::ERROR);
+    // Just testing it doesn't throw
+    SUCCEED();
+}
+
+TEST_F(NamedSinksTest, NamedAndUnnamedMixed) {
+    minta::LunarLog logger(minta::LogLevel::INFO, false);
+    logger.addSink<minta::FileSink>("test_unnamed.txt"); // auto: sink_0
+    logger.addSink<minta::FileSink>("named", "test_named_mix.txt");
+    logger.addSink<minta::FileSink>("test_unnamed2.txt"); // auto: sink_2
+    // All three should receive logs
+    logger.info("Mixed sinks");
+    logger.flush();
+    TestUtils::waitForFileContent("test_unnamed.txt");
+    TestUtils::waitForFileContent("test_named_mix.txt");
+    TestUtils::waitForFileContent("test_unnamed2.txt");
+    std::string c1 = TestUtils::readLogFile("test_unnamed.txt");
+    std::string c2 = TestUtils::readLogFile("test_named_mix.txt");
+    std::string c3 = TestUtils::readLogFile("test_unnamed2.txt");
+    EXPECT_TRUE(c1.find("Mixed sinks") != std::string::npos);
+    EXPECT_TRUE(c2.find("Mixed sinks") != std::string::npos);
+    EXPECT_TRUE(c3.find("Mixed sinks") != std::string::npos);
+}
+
+TEST_F(NamedSinksTest, SinkProxyLocale) {
+    minta::LunarLog logger(minta::LogLevel::INFO, false);
+    logger.addSink<minta::FileSink>("loc", "test_locale.txt");
+    logger.sink("loc").locale("en_US.UTF-8");
+    logger.info("Locale test");
+    logger.flush();
+    TestUtils::waitForFileContent("test_locale.txt");
+    std::string content = TestUtils::readLogFile("test_locale.txt");
+    EXPECT_TRUE(content.find("Locale test") != std::string::npos);
+}
+
+TEST_F(NamedSinksTest, EmptyNameThrowsOnDuplicate) {
+    // Empty string is a valid name
+    minta::LunarLog logger(minta::LogLevel::INFO, false);
+    logger.addSink<minta::FileSink>("", "test_empty_name.txt");
+    EXPECT_THROW(logger.addSink<minta::FileSink>("", "test_empty_name2.txt"), std::invalid_argument);
+}
+
+TEST_F(NamedSinksTest, AddSinkAfterLoggingThrows) {
+    minta::LunarLog logger(minta::LogLevel::INFO, false);
+    logger.addSink<minta::FileSink>("pre", "test_pre.txt");
+    logger.info("Start logging");
+    logger.flush();
+    // After logging starts, adding sinks should throw
+    EXPECT_THROW(logger.addSink<minta::FileSink>("post", "test_post.txt"), std::logic_error);
+}
+
+TEST_F(NamedSinksTest, SinkProxyFormatterChange) {
+    minta::LunarLog logger(minta::LogLevel::INFO, false);
+    logger.addSink<minta::FileSink>("fmt", "test_fmt.txt");
+    logger.sink("fmt").formatter(minta::detail::make_unique<minta::JsonFormatter>());
+    logger.info("JSON format");
+    logger.flush();
+    TestUtils::waitForFileContent("test_fmt.txt");
+    std::string content = TestUtils::readLogFile("test_fmt.txt");
+    EXPECT_TRUE(content.find("\"level\":\"INFO\"") != std::string::npos);
+}
+
+TEST_F(NamedSinksTest, MultipleProxyCallsOnSameSink) {
+    minta::LunarLog logger(minta::LogLevel::TRACE, false);
+    logger.addSink<minta::FileSink>("multi", "test_multi_proxy.txt");
+    logger.sink("multi").level(minta::LogLevel::WARN).filterRule("level >= WARN");
+    logger.trace("Trace msg");
+    logger.warn("Warn msg");
+    logger.flush();
+    TestUtils::waitForFileContent("test_multi_proxy.txt");
+    std::string content = TestUtils::readLogFile("test_multi_proxy.txt");
+    EXPECT_TRUE(content.find("Trace msg") == std::string::npos);
+    EXPECT_TRUE(content.find("Warn msg") != std::string::npos);
+}
+
+TEST_F(NamedSinksTest, AddSinkConsoleSinkNamed) {
+    minta::LunarLog logger(minta::LogLevel::INFO, false);
+    logger.addSink<minta::ConsoleSink>("console");
+    logger.sink("console").level(minta::LogLevel::ERROR);
+    SUCCEED();
+}
+
+TEST_F(NamedSinksTest, AddCustomSinkNamed) {
+    minta::LunarLog logger(minta::LogLevel::INFO, false);
+    auto sink = minta::detail::make_unique<minta::ConsoleSink>();
+    logger.addCustomSink("custom", std::move(sink));
+    logger.sink("custom").level(minta::LogLevel::WARN);
+    SUCCEED();
+}
+
+TEST_F(NamedSinksTest, NamedSinkJsonFormatterSpecExample) {
+    minta::LunarLog logger(minta::LogLevel::INFO, false);
+    logger.addSink<minta::FileSink, minta::JsonFormatter>("json-out", "test_spec_json.txt");
+    logger.info("Spec example {val}", 42);
+    logger.flush();
+    TestUtils::waitForFileContent("test_spec_json.txt");
+    std::string content = TestUtils::readLogFile("test_spec_json.txt");
+    EXPECT_TRUE(content.find("\"level\":\"INFO\"") != std::string::npos);
+}
+
+TEST_F(NamedSinksTest, AutoNameCollisionSkips) {
+    // H1/M10: User names a sink "sink_0", then adds an unnamed sink.
+    // Auto-naming should skip "sink_0" and use "sink_1" (or next free).
+    minta::LunarLog logger(minta::LogLevel::INFO, false);
+    logger.addSink<minta::FileSink>("sink_0", "test_collision_named.txt");
+    logger.addSink<minta::FileSink>("test_collision_auto.txt"); // should get "sink_1", not "sink_0"
+    // Verify auto-named sink is accessible and didn't collide
+    logger.sink("sink_1").level(minta::LogLevel::ERROR);
+    logger.info("Info msg");
+    logger.error("Error msg");
+    logger.flush();
+    TestUtils::waitForFileContent("test_collision_named.txt");
+    TestUtils::waitForFileContent("test_collision_auto.txt");
+    std::string namedContent = TestUtils::readLogFile("test_collision_named.txt");
+    std::string autoContent = TestUtils::readLogFile("test_collision_auto.txt");
+    // Named sink (sink_0) should have both messages (default level TRACE)
+    EXPECT_TRUE(namedContent.find("Info msg") != std::string::npos);
+    EXPECT_TRUE(namedContent.find("Error msg") != std::string::npos);
+    // Auto sink (sink_1) should only have error (level set to ERROR)
+    EXPECT_TRUE(autoContent.find("Info msg") == std::string::npos);
+    EXPECT_TRUE(autoContent.find("Error msg") != std::string::npos);
+}
+
+TEST_F(NamedSinksTest, SinkProxyFormatterThrowsAfterLogging) {
+    minta::LunarLog logger(minta::LogLevel::INFO, false);
+    logger.addSink<minta::FileSink>("fmt_throw", "test_fmt_throw.txt");
+    logger.info("Start logging to trigger m_loggingStarted");
+    logger.flush();
+    // formatter() should throw after logging has started
+    EXPECT_THROW(
+        logger.sink("fmt_throw").formatter(
+            minta::detail::make_unique<minta::JsonFormatter>()),
+        std::logic_error);
+}
+
+TEST_F(NamedSinksTest, SinkProxyFilterPredicate) {
+    minta::LunarLog logger(minta::LogLevel::TRACE, false);
+    logger.addSink<minta::FileSink>("pred", "test_pred_filter.txt");
+    // Set a predicate filter that only allows ERROR+
+    logger.sink("pred").filter([](const minta::LogEntry& entry) {
+        return entry.level >= minta::LogLevel::ERROR;
+    });
+    logger.info("Should be filtered out");
+    logger.error("Should pass through");
+    logger.flush();
+    TestUtils::waitForFileContent("test_pred_filter.txt");
+    std::string content = TestUtils::readLogFile("test_pred_filter.txt");
+    EXPECT_TRUE(content.find("Should be filtered out") == std::string::npos);
+    EXPECT_TRUE(content.find("Should pass through") != std::string::npos);
+}
+
+TEST_F(NamedSinksTest, ThreeSinksWithDifferentLevels) {
+    minta::LunarLog logger(minta::LogLevel::TRACE, false);
+    logger.addSink<minta::FileSink>("trace", "test_trace.txt");
+    logger.addSink<minta::FileSink>("info", "test_info_lvl.txt");
+    logger.addSink<minta::FileSink>("error", "test_error_lvl.txt");
+    logger.sink("info").level(minta::LogLevel::INFO);
+    logger.sink("error").level(minta::LogLevel::ERROR);
+    
+    logger.trace("Trace msg");
+    logger.info("Info msg");
+    logger.error("Error msg");
+    logger.flush();
+    
+    TestUtils::waitForFileContent("test_trace.txt");
+    TestUtils::waitForFileContent("test_info_lvl.txt");
+    TestUtils::waitForFileContent("test_error_lvl.txt");
+    
+    std::string traceContent = TestUtils::readLogFile("test_trace.txt");
+    std::string infoContent = TestUtils::readLogFile("test_info_lvl.txt");
+    std::string errorContent = TestUtils::readLogFile("test_error_lvl.txt");
+    
+    EXPECT_TRUE(traceContent.find("Trace msg") != std::string::npos);
+    EXPECT_TRUE(traceContent.find("Info msg") != std::string::npos);
+    EXPECT_TRUE(traceContent.find("Error msg") != std::string::npos);
+    
+    EXPECT_TRUE(infoContent.find("Trace msg") == std::string::npos);
+    EXPECT_TRUE(infoContent.find("Info msg") != std::string::npos);
+    EXPECT_TRUE(infoContent.find("Error msg") != std::string::npos);
+    
+    EXPECT_TRUE(errorContent.find("Trace msg") == std::string::npos);
+    EXPECT_TRUE(errorContent.find("Info msg") == std::string::npos);
+    EXPECT_TRUE(errorContent.find("Error msg") != std::string::npos);
+}

--- a/test/tests/test_tag_routing.cpp
+++ b/test/tests/test_tag_routing.cpp
@@ -1,0 +1,310 @@
+#include <gtest/gtest.h>
+#include "lunar_log.hpp"
+#include "utils/test_utils.hpp"
+
+class TagRoutingTest : public ::testing::Test {
+protected:
+    void SetUp() override { TestUtils::cleanupLogFiles(); }
+    void TearDown() override { TestUtils::cleanupLogFiles(); }
+};
+
+// --- Tag parsing tests ---
+
+TEST_F(TagRoutingTest, ParseSingleTag) {
+    auto result = minta::detail::parseTags("[metrics] Request took 100ms");
+    EXPECT_EQ(result.first.size(), 1u);
+    EXPECT_EQ(result.first[0], "metrics");
+    EXPECT_EQ(result.second, "Request took 100ms");
+}
+
+TEST_F(TagRoutingTest, ParseMultipleTags) {
+    auto result = minta::detail::parseTags("[audit][security] Admin action");
+    EXPECT_EQ(result.first.size(), 2u);
+    EXPECT_EQ(result.first[0], "audit");
+    EXPECT_EQ(result.first[1], "security");
+    EXPECT_EQ(result.second, "Admin action");
+}
+
+TEST_F(TagRoutingTest, ParseNoTags) {
+    auto result = minta::detail::parseTags("Normal message");
+    EXPECT_TRUE(result.first.empty());
+    EXPECT_EQ(result.second, "Normal message");
+}
+
+TEST_F(TagRoutingTest, ParseTagWithHyphensUnderscores) {
+    auto result = minta::detail::parseTags("[my-tag_2] Message");
+    EXPECT_EQ(result.first.size(), 1u);
+    EXPECT_EQ(result.first[0], "my-tag_2");
+    EXPECT_EQ(result.second, "Message");
+}
+
+TEST_F(TagRoutingTest, ParseInvalidTagChars) {
+    // Tags with spaces or special chars should stop parsing
+    auto result = minta::detail::parseTags("[invalid tag] Message");
+    EXPECT_TRUE(result.first.empty());
+    EXPECT_EQ(result.second, "[invalid tag] Message");
+}
+
+TEST_F(TagRoutingTest, ParseEmptyBrackets) {
+    auto result = minta::detail::parseTags("[] Message");
+    EXPECT_TRUE(result.first.empty());
+    EXPECT_EQ(result.second, "[] Message");
+}
+
+TEST_F(TagRoutingTest, ParseUnclosedBracket) {
+    auto result = minta::detail::parseTags("[unclosed Message");
+    EXPECT_TRUE(result.first.empty());
+    EXPECT_EQ(result.second, "[unclosed Message");
+}
+
+TEST_F(TagRoutingTest, ParseTagsNotAtStart) {
+    auto result = minta::detail::parseTags("Prefix [tag] message");
+    EXPECT_TRUE(result.first.empty());
+    EXPECT_EQ(result.second, "Prefix [tag] message");
+}
+
+// --- Tag routing to sinks ---
+
+TEST_F(TagRoutingTest, OnlyTagRouting) {
+    minta::LunarLog logger(minta::LogLevel::INFO, false);
+    logger.addSink<minta::FileSink>("metrics", "test_metrics.txt");
+    logger.addSink<minta::FileSink>("all", "test_all_tags.txt");
+    logger.sink("metrics").only("metrics");
+    
+    logger.info("[metrics] Request count: {count}", 42);
+    logger.info("Regular log message");
+    logger.flush();
+    
+    TestUtils::waitForFileContent("test_metrics.txt");
+    TestUtils::waitForFileContent("test_all_tags.txt");
+    
+    std::string metricsContent = TestUtils::readLogFile("test_metrics.txt");
+    std::string allContent = TestUtils::readLogFile("test_all_tags.txt");
+    
+    EXPECT_TRUE(metricsContent.find("Request count: 42") != std::string::npos);
+    EXPECT_TRUE(metricsContent.find("Regular log message") == std::string::npos);
+    
+    EXPECT_TRUE(allContent.find("Regular log message") != std::string::npos);
+    // Untagged sink receives logs without tags
+}
+
+TEST_F(TagRoutingTest, ExceptTagRouting) {
+    minta::LunarLog logger(minta::LogLevel::INFO, false);
+    logger.addSink<minta::FileSink>("no-debug", "test_no_debug.txt");
+    logger.sink("no-debug").except("debug");
+    
+    logger.info("[debug] Debug info");
+    logger.info("Normal message");
+    logger.flush();
+    
+    TestUtils::waitForFileContent("test_no_debug.txt");
+    std::string content = TestUtils::readLogFile("test_no_debug.txt");
+    
+    EXPECT_TRUE(content.find("Debug info") == std::string::npos);
+    EXPECT_TRUE(content.find("Normal message") != std::string::npos);
+}
+
+TEST_F(TagRoutingTest, OnlyTakesPrecedenceOverExcept) {
+    minta::LunarLog logger(minta::LogLevel::INFO, false);
+    logger.addSink<minta::FileSink>("mixed", "test_mixed_tags.txt");
+    logger.sink("mixed").only("audit").except("audit");
+    
+    logger.info("[audit] Audit event");
+    logger.flush();
+    
+    TestUtils::waitForFileContent("test_mixed_tags.txt");
+    std::string content = TestUtils::readLogFile("test_mixed_tags.txt");
+    
+    // only() takes precedence, so audit tag matches only() -> accepted
+    EXPECT_TRUE(content.find("Audit event") != std::string::npos);
+}
+
+TEST_F(TagRoutingTest, NoTagsGoToSinksWithoutOnlyFilter) {
+    minta::LunarLog logger(minta::LogLevel::INFO, false);
+    logger.addSink<minta::FileSink>("specific", "test_specific.txt");
+    logger.addSink<minta::FileSink>("general", "test_general.txt");
+    logger.sink("specific").only("metrics");
+    
+    logger.info("No tags here");
+    logger.flush();
+    
+    TestUtils::waitForFileContent("test_general.txt");
+    std::string specificContent = TestUtils::readLogFile("test_specific.txt");
+    std::string generalContent = TestUtils::readLogFile("test_general.txt");
+    
+    EXPECT_TRUE(specificContent.find("No tags here") == std::string::npos);
+    EXPECT_TRUE(generalContent.find("No tags here") != std::string::npos);
+}
+
+TEST_F(TagRoutingTest, MultipleOnlyTags) {
+    minta::LunarLog logger(minta::LogLevel::INFO, false);
+    logger.addSink<minta::FileSink>("combo", "test_combo.txt");
+    logger.sink("combo").only("audit").only("security");
+    
+    logger.info("[audit] Audit event");
+    logger.info("[security] Security event");
+    logger.info("[other] Other event");
+    logger.flush();
+    
+    TestUtils::waitForFileContent("test_combo.txt");
+    std::string content = TestUtils::readLogFile("test_combo.txt");
+    
+    EXPECT_TRUE(content.find("Audit event") != std::string::npos);
+    EXPECT_TRUE(content.find("Security event") != std::string::npos);
+    EXPECT_TRUE(content.find("Other event") == std::string::npos);
+}
+
+TEST_F(TagRoutingTest, MultiTagMessage) {
+    minta::LunarLog logger(minta::LogLevel::INFO, false);
+    logger.addSink<minta::FileSink>("audit", "test_audit.txt");
+    logger.sink("audit").only("audit");
+    
+    logger.info("[audit][security] Multi-tag event");
+    logger.flush();
+    
+    TestUtils::waitForFileContent("test_audit.txt");
+    std::string content = TestUtils::readLogFile("test_audit.txt");
+    EXPECT_TRUE(content.find("Multi-tag event") != std::string::npos);
+}
+
+TEST_F(TagRoutingTest, TagsStrippedFromHumanReadable) {
+    minta::LunarLog logger(minta::LogLevel::INFO, false);
+    logger.addSink<minta::FileSink>("human", "test_human_tags.txt");
+    
+    logger.info("[metrics] Request took {ms}ms", 100);
+    logger.flush();
+    
+    TestUtils::waitForFileContent("test_human_tags.txt");
+    std::string content = TestUtils::readLogFile("test_human_tags.txt");
+    
+    // Message should not contain [metrics] prefix
+    EXPECT_TRUE(content.find("[metrics]") == std::string::npos);
+    EXPECT_TRUE(content.find("Request took 100ms") != std::string::npos);
+}
+
+TEST_F(TagRoutingTest, TagsInJsonOutput) {
+    minta::LunarLog logger(minta::LogLevel::INFO, false);
+    logger.addSink<minta::FileSink, minta::JsonFormatter>("json", "test_json_tags.txt");
+    
+    logger.info("[metrics][perf] Latency {ms}ms", 50);
+    logger.flush();
+    
+    TestUtils::waitForFileContent("test_json_tags.txt");
+    std::string content = TestUtils::readLogFile("test_json_tags.txt");
+    
+    EXPECT_TRUE(content.find("\"tags\":[\"metrics\",\"perf\"]") != std::string::npos);
+    EXPECT_TRUE(content.find("Latency 50ms") != std::string::npos);
+}
+
+TEST_F(TagRoutingTest, TagsInXmlOutput) {
+    minta::LunarLog logger(minta::LogLevel::INFO, false);
+    logger.addSink<minta::FileSink, minta::XmlFormatter>("xml", "test_xml_tags.txt");
+    
+    logger.info("[audit] Event occurred");
+    logger.flush();
+    
+    TestUtils::waitForFileContent("test_xml_tags.txt");
+    std::string content = TestUtils::readLogFile("test_xml_tags.txt");
+    
+    EXPECT_TRUE(content.find("<tags><tag>audit</tag></tags>") != std::string::npos);
+}
+
+TEST_F(TagRoutingTest, ClearTagFilters) {
+    minta::LunarLog logger(minta::LogLevel::INFO, false);
+    logger.addSink<minta::FileSink>("clear", "test_clear_tags.txt");
+    logger.sink("clear").only("audit");
+    logger.sink("clear").clearTagFilters();
+    
+    logger.info("Should now be visible");
+    logger.flush();
+    
+    TestUtils::waitForFileContent("test_clear_tags.txt");
+    std::string content = TestUtils::readLogFile("test_clear_tags.txt");
+    EXPECT_TRUE(content.find("Should now be visible") != std::string::npos);
+}
+
+TEST_F(TagRoutingTest, ExceptMultipleTags) {
+    minta::LunarLog logger(minta::LogLevel::INFO, false);
+    logger.addSink<minta::FileSink>("exc", "test_exc.txt");
+    logger.sink("exc").except("debug").except("trace");
+    
+    logger.info("[debug] Debug msg");
+    logger.info("[trace] Trace msg");
+    logger.info("[audit] Audit msg");
+    logger.info("Normal msg");
+    logger.flush();
+    
+    TestUtils::waitForFileContent("test_exc.txt");
+    std::string content = TestUtils::readLogFile("test_exc.txt");
+    
+    EXPECT_TRUE(content.find("Debug msg") == std::string::npos);
+    EXPECT_TRUE(content.find("Trace msg") == std::string::npos);
+    EXPECT_TRUE(content.find("Audit msg") != std::string::npos);
+    EXPECT_TRUE(content.find("Normal msg") != std::string::npos);
+}
+
+TEST_F(TagRoutingTest, TagWithPlaceholders) {
+    auto result = minta::detail::parseTags("[metrics] Request {method} took {ms}ms");
+    EXPECT_EQ(result.first.size(), 1u);
+    EXPECT_EQ(result.first[0], "metrics");
+    EXPECT_EQ(result.second, "Request {method} took {ms}ms");
+}
+
+TEST_F(TagRoutingTest, NoTagsNoFilterAllSinksReceive) {
+    minta::LunarLog logger(minta::LogLevel::INFO, false);
+    logger.addSink<minta::FileSink>("s1", "test_notag1.txt");
+    logger.addSink<minta::FileSink>("s2", "test_notag2.txt");
+    
+    logger.info("Broadcast message");
+    logger.flush();
+    
+    TestUtils::waitForFileContent("test_notag1.txt");
+    TestUtils::waitForFileContent("test_notag2.txt");
+    
+    EXPECT_TRUE(TestUtils::readLogFile("test_notag1.txt").find("Broadcast message") != std::string::npos);
+    EXPECT_TRUE(TestUtils::readLogFile("test_notag2.txt").find("Broadcast message") != std::string::npos);
+}
+
+TEST_F(TagRoutingTest, TagRoutingCombinedWithLevel) {
+    minta::LunarLog logger(minta::LogLevel::TRACE, false);
+    logger.addSink<minta::FileSink>("metrics-warn", "test_metrics_warn.txt");
+    logger.sink("metrics-warn").only("metrics").level(minta::LogLevel::WARN);
+    
+    logger.info("[metrics] Info metric");
+    logger.warn("[metrics] Warn metric");
+    logger.info("Normal info");
+    logger.flush();
+    
+    TestUtils::waitForFileContent("test_metrics_warn.txt");
+    std::string content = TestUtils::readLogFile("test_metrics_warn.txt");
+    
+    EXPECT_TRUE(content.find("Info metric") == std::string::npos);
+    EXPECT_TRUE(content.find("Warn metric") != std::string::npos);
+    EXPECT_TRUE(content.find("Normal info") == std::string::npos);
+}
+
+TEST_F(TagRoutingTest, OnlyTagNumericName) {
+    auto result = minta::detail::parseTags("[tag123] Message");
+    EXPECT_EQ(result.first.size(), 1u);
+    EXPECT_EQ(result.first[0], "tag123");
+}
+
+TEST_F(TagRoutingTest, NestedBracketsNotParsed) {
+    // Brackets inside content should not parse
+    auto result = minta::detail::parseTags("[[inner]] Message");
+    // First [ starts, second [ is invalid char for tag
+    EXPECT_TRUE(result.first.empty());
+}
+
+TEST_F(TagRoutingTest, TagsWithArgumentsFormatted) {
+    minta::LunarLog logger(minta::LogLevel::INFO, false);
+    logger.addSink<minta::FileSink>("fmtarg", "test_fmtarg.txt");
+    
+    logger.info("[perf] Processed {count} items in {time}s", 100, 2.5);
+    logger.flush();
+    
+    TestUtils::waitForFileContent("test_fmtarg.txt");
+    std::string content = TestUtils::readLogFile("test_fmtarg.txt");
+    EXPECT_TRUE(content.find("Processed 100 items in 2.5s") != std::string::npos);
+    EXPECT_TRUE(content.find("[perf]") == std::string::npos);
+}

--- a/test/tests/utils/test_utils.cpp
+++ b/test/tests/utils/test_utils.cpp
@@ -62,7 +62,26 @@ void TestUtils::cleanupLogFiles() {
         "culture_conc_sink_test.txt", "culture_locale_change_test.txt",
         "culture_mixed_spec_test.txt",
         "culture_multi0_test.txt", "culture_multi1_test.txt", "culture_multi2_test.txt",
-        "culture_reset_test.txt"
+        "culture_reset_test.txt",
+        // Named sinks tests
+        "test_named1.txt", "test_dup1.txt", "test_dup2.txt",
+        "test_errors.txt", "test_chained.txt", "test_auto0.txt",
+        "test_named_json.txt", "test_all.txt", "test_err_only.txt",
+        "test_idx.txt", "test_filtered.txt", "test_clr.txt",
+        "test_unnamed.txt", "test_named_mix.txt", "test_unnamed2.txt",
+        "test_locale.txt", "test_empty_name.txt", "test_empty_name2.txt",
+        "test_pre.txt", "test_post.txt", "test_fmt.txt", "test_fmt_throw.txt",
+        "test_pred_filter.txt",
+        "test_collision_named.txt", "test_collision_auto.txt",
+        "test_multi_proxy.txt", "test_trace.txt", "test_info_lvl.txt",
+        "test_error_lvl.txt", "test_spec_json.txt",
+        // Tag routing tests
+        "test_metrics.txt", "test_all_tags.txt", "test_no_debug.txt",
+        "test_mixed_tags.txt", "test_specific.txt", "test_general.txt",
+        "test_combo.txt", "test_audit.txt", "test_human_tags.txt",
+        "test_json_tags.txt", "test_xml_tags.txt", "test_clear_tags.txt",
+        "test_exc.txt", "test_notag1.txt", "test_notag2.txt",
+        "test_metrics_warn.txt", "test_fmtarg.txt"
     };
 
     for (const auto &filename : filesToRemove) {


### PR DESCRIPTION
## Issue #35 — Named Sinks & Tag Routing

Route log entries to specific sinks by name, and filter routing with `[tag]` prefixes in message templates.

### What's new

- **Named sinks** — register sinks with string names via `named("console")` factory
- **SinkProxy fluent API** — configure per-sink level, filters, locale, formatter, and tag routing through a chainable proxy
- **Tag parsing** — `[audit][security] User login` extracts tags from the message prefix, strips them from output
- **Only/except filtering** — `only("audit")` routes entries exclusively to tagged sinks; `except("debug")` excludes
- **Auto-naming** — unnamed sinks get collision-safe names (`sink_0`, `sink_1`, ...)
- **JSON/XML tag output** — tags array serialized in structured formatters
- **SinkName tag type** — SFINAE disambiguation prevents ambiguity when SinkType is constructible from `std::string`

### API

```cpp
auto logger = std::make_shared<LunarLog>();

// Register named sinks
auto proxy = logger->addSink<ConsoleSink>(named("console"));
proxy.level(LogLevel::WARN);

logger->addSink<FileSink>(named("audit"), "audit.log");
logger->sink("audit").only("audit");

// Tag routing — only the "audit" sink receives this
logger->info("[audit] Sensitive operation performed by {user}", "user", "alice");

// Regular log — goes to all sinks matching level
logger->warn("Something happened");
```

### Design decisions

- **`SinkName` tag type + `named()` factory**: avoids SFINAE ambiguity when sink constructors accept `std::string`
- **`detail::parseTags()`**: tags must be adjacent `[a][b]`, spaces break the scan — keeps parsing simple and predictable
- **Atomic fast-path `m_hasTagFilters`**: zero overhead when no tag routing is configured
- **`clearTagFilters()` separate from `clearFilters()`**: tag routing and level/predicate/DSL filters are independent concerns
- **Copy-then-evaluate**: tag sets copied under lock, matching done outside — minimal lock contention

### Changes

| File | What |
|------|------|
| `log_source.hpp` | `SinkName`, `named()`, `parseTags()`, named sink add/get/remove, `sink()` proxy accessor |
| `sink_interface.hpp` | Tag storage (`only`/`except` sets), `m_hasTagFilters` atomic, `shouldReceive()` |
| `log_manager.hpp` | Name registry, auto-naming, name-based lookup/removal, tag-aware dispatch |
| `log_entry.hpp` | `tags` field on `LogEntry` |
| `json_formatter.hpp` | Tags array in JSON output |
| `xml_formatter.hpp` | `<Tags>` element in XML output |
| `test_named_sinks.cpp` | 25 tests — registration, proxy API, auto-naming, collisions, removal |
| `test_tag_routing.cpp` | 25 tests — parsing, only/except, multi-tag, JSON/XML output, edge cases |
| `test_utils.cpp` | Updated assertion helpers |

### Tests

**303 tests total** (253 existing + 50 new), passing across gcc (C++11/14/17), clang 17, AppleClang, MSVC.

### Review history

- R1: Sisyphus review — 4 High, 6 Medium, 7 Low findings → all fixed
- R2: Self-review — 0/0/0/0 clean

Closes #35