### PR TITLE
use shared_mutex for read-heavy hot path locks

### DIFF
--- a/include/lunar_log/core/shared_mutex.hpp
+++ b/include/lunar_log/core/shared_mutex.hpp
@@ -1,0 +1,27 @@
+#ifndef LUNAR_LOG_SHARED_MUTEX_HPP
+#define LUNAR_LOG_SHARED_MUTEX_HPP
+
+#include <mutex>
+#if __cplusplus >= 201703L || (defined(_MSVC_LANG) && _MSVC_LANG >= 201703L)
+#include <shared_mutex>
+#endif
+
+namespace minta {
+namespace detail {
+
+// C++17: use shared_mutex for read-heavy hot paths (template cache,
+// locale, context, global filters). Falls back to std::mutex on C++11/14.
+#if __cplusplus >= 201703L || (defined(_MSVC_LANG) && _MSVC_LANG >= 201703L)
+    using SharedMutex = std::shared_mutex;
+    template<typename M> using ReadLock  = std::shared_lock<M>;
+#else
+    using SharedMutex = std::mutex;
+    template<typename M> using ReadLock  = std::lock_guard<M>;
+#endif
+    // WriteLock is always unique_lock for API parity across standards
+    template<typename M> using WriteLock = std::unique_lock<M>;
+
+} // namespace detail
+} // namespace minta
+
+#endif // LUNAR_LOG_SHARED_MUTEX_HPP

--- a/include/lunar_log/core/sink_proxy.hpp
+++ b/include/lunar_log/core/sink_proxy.hpp
@@ -81,6 +81,24 @@ namespace minta {
             return *this;
         }
 
+        SinkProxy& clearOnlyTags() {
+            m_sink->clearOnlyTags();
+            return *this;
+        }
+
+        SinkProxy& clearExceptTags() {
+            m_sink->clearExceptTags();
+            return *this;
+        }
+
+        std::set<std::string> getOnlyTags() const {
+            return m_sink->getOnlyTags();
+        }
+
+        std::set<std::string> getExceptTags() const {
+            return m_sink->getExceptTags();
+        }
+
         /// Set the output template for text-based formatters.
         /// Only applies to HumanReadableFormatter. No-op for JSON/XML formatters.
         SinkProxy& outputTemplate(const std::string& templateStr) {

--- a/include/lunar_log/formatter/formatter_interface.hpp
+++ b/include/lunar_log/formatter/formatter_interface.hpp
@@ -3,6 +3,7 @@
 
 #include "../core/log_entry.hpp"
 #include "../core/log_common.hpp"
+#include "../core/shared_mutex.hpp"
 #include <string>
 #include <vector>
 #include <mutex>
@@ -19,12 +20,12 @@ namespace minta {
         /// this locale instead of the logger-level locale stored in the entry.
         /// Thread-safe: can be called concurrently with format().
         void setLocale(const std::string& locale) {
-            std::lock_guard<std::mutex> lock(m_localeMutex);
+            detail::WriteLock<detail::SharedMutex> lock(m_localeMutex);
             m_locale = locale;
         }
 
         std::string getLocale() const {
-            std::lock_guard<std::mutex> lock(m_localeMutex);
+            detail::ReadLock<detail::SharedMutex> lock(m_localeMutex);
             return m_locale;
         }
 
@@ -36,7 +37,7 @@ namespace minta {
             // Copy locale under lock, then use the copy outside.
             std::string localeCopy;
             {
-                std::lock_guard<std::mutex> lock(m_localeMutex);
+                detail::ReadLock<detail::SharedMutex> lock(m_localeMutex);
                 localeCopy = m_locale;
             }
             if (localeCopy.empty() || localeCopy == entry.locale) {
@@ -81,7 +82,7 @@ namespace minta {
         }
 
     private:
-        mutable std::mutex m_localeMutex;
+        mutable detail::SharedMutex m_localeMutex;
         std::string m_locale;
     };
 } // namespace minta

--- a/include/lunar_log/log_source.hpp
+++ b/include/lunar_log/log_source.hpp
@@ -14,6 +14,7 @@
 #include "log_manager.hpp"
 #include "sink/console_sink.hpp"
 #include "formatter/human_readable_formatter.hpp"
+#include "core/shared_mutex.hpp"
 #include <atomic>
 #include <mutex>
 #include <type_traits>
@@ -387,20 +388,20 @@ namespace detail {
         ///       Filter predicates must capture state by value.  Referenced
         ///       objects must outlive the logger.
         void setFilter(FilterPredicate filter) {
-            std::lock_guard<std::mutex> lock(m_globalFilterMutex);
+            detail::WriteLock<detail::SharedMutex> lock(m_globalFilterMutex);
             m_globalFilter = std::make_shared<const FilterPredicate>(std::move(filter));
             m_hasGlobalFilters.store(true, std::memory_order_release);
         }
 
         void clearFilter() {
-            std::lock_guard<std::mutex> lock(m_globalFilterMutex);
+            detail::WriteLock<detail::SharedMutex> lock(m_globalFilterMutex);
             m_globalFilter.reset();
             m_hasGlobalFilters.store(m_globalFilterRules && !m_globalFilterRules->empty(), std::memory_order_release);
         }
 
         void addFilterRule(const std::string& ruleStr) {
             FilterRule rule = FilterRule::parse(ruleStr);
-            std::lock_guard<std::mutex> lock(m_globalFilterMutex);
+            detail::WriteLock<detail::SharedMutex> lock(m_globalFilterMutex);
             auto newRules = std::make_shared<std::vector<FilterRule>>(
                 m_globalFilterRules ? *m_globalFilterRules : std::vector<FilterRule>());
             newRules->push_back(std::move(rule));
@@ -409,13 +410,13 @@ namespace detail {
         }
 
         void clearFilterRules() {
-            std::lock_guard<std::mutex> lock(m_globalFilterMutex);
+            detail::WriteLock<detail::SharedMutex> lock(m_globalFilterMutex);
             m_globalFilterRules.reset();
             m_hasGlobalFilters.store(m_globalFilter && static_cast<bool>(*m_globalFilter), std::memory_order_release);
         }
 
         void clearAllFilters() {
-            std::lock_guard<std::mutex> lock(m_globalFilterMutex);
+            detail::WriteLock<detail::SharedMutex> lock(m_globalFilterMutex);
             m_globalFilter.reset();
             m_globalFilterRules.reset();
             m_hasGlobalFilters.store(false, std::memory_order_release);
@@ -428,7 +429,7 @@ namespace detail {
         void filter(const std::string& compactExpr) {
             std::vector<FilterRule> rules = detail::parseCompactFilter(compactExpr);
             if (rules.empty()) return;
-            std::lock_guard<std::mutex> lock(m_globalFilterMutex);
+            detail::WriteLock<detail::SharedMutex> lock(m_globalFilterMutex);
             auto newRules = std::make_shared<std::vector<FilterRule>>(
                 m_globalFilterRules ? *m_globalFilterRules : std::vector<FilterRule>());
             newRules->reserve(newRules->size() + rules.size());
@@ -464,19 +465,19 @@ namespace detail {
         }
 
         void setContext(const std::string& key, const std::string& value) {
-            std::lock_guard<std::mutex> lock(m_contextMutex);
+            detail::WriteLock<detail::SharedMutex> lock(m_contextMutex);
             m_customContext[key] = value;
             m_hasCustomContext.store(true, std::memory_order_release);
         }
 
         void clearContext(const std::string& key) {
-            std::lock_guard<std::mutex> lock(m_contextMutex);
+            detail::WriteLock<detail::SharedMutex> lock(m_contextMutex);
             m_customContext.erase(key);
             m_hasCustomContext.store(!m_customContext.empty(), std::memory_order_release);
         }
 
         void clearAllContext() {
-            std::lock_guard<std::mutex> lock(m_contextMutex);
+            detail::WriteLock<detail::SharedMutex> lock(m_contextMutex);
             m_customContext.clear();
             m_hasCustomContext.store(false, std::memory_order_release);
         }
@@ -489,7 +490,7 @@ namespace detail {
         /// they remain accessible for lookups but no new entries are
         /// inserted until the map size drops below the new cap.
         void setTemplateCacheSize(size_t size) {
-            std::lock_guard<std::mutex> lock(m_cacheMutex);
+            detail::WriteLock<detail::SharedMutex> lock(m_cacheMutex);
             m_templateCacheSize = size;
             if (size == 0) {
                 m_templateCache.clear();
@@ -497,13 +498,13 @@ namespace detail {
         }
 
         void setLocale(const std::string& locale) {
-            std::lock_guard<std::mutex> lock(m_localeMutex);
+            detail::WriteLock<detail::SharedMutex> lock(m_localeMutex);
             m_locale = locale;
             m_hasLocale.store(locale != "C" && locale != "POSIX" && !locale.empty(), std::memory_order_release);
         }
 
         std::string getLocale() const {
-            std::lock_guard<std::mutex> lock(m_localeMutex);
+            detail::ReadLock<detail::SharedMutex> lock(m_localeMutex);
             return m_locale;
         }
 
@@ -632,7 +633,7 @@ namespace detail {
         }
 
         void replaceFilterRules(std::vector<FilterRule> rules) {
-            std::lock_guard<std::mutex> lock(m_globalFilterMutex);
+            detail::WriteLock<detail::SharedMutex> lock(m_globalFilterMutex);
             if (rules.empty()) {
                 m_globalFilterRules.reset();
             } else {
@@ -650,7 +651,7 @@ namespace detail {
         std::atomic<bool> m_isRunning;
         std::atomic<long long> m_rateLimitWindowStart;
         std::atomic<size_t> m_logCount;
-        std::mutex m_contextMutex;
+        detail::SharedMutex m_contextMutex;
         LogManager m_logManager;
         std::map<std::string, std::string> m_customContext;
         std::atomic<bool> m_captureSourceLocation;
@@ -668,16 +669,16 @@ namespace detail {
             int alignment;   // >0 right-align, <0 left-align, 0 = none
         };
 
-        std::mutex m_cacheMutex;
+        detail::SharedMutex m_cacheMutex;
         std::unordered_map<std::string, std::shared_ptr<const std::vector<PlaceholderInfo>>> m_templateCache;
         size_t m_templateCacheSize;
 
-        std::mutex m_globalFilterMutex;
+        detail::SharedMutex m_globalFilterMutex;
         std::atomic<bool> m_hasGlobalFilters;
         std::shared_ptr<const FilterPredicate> m_globalFilter;
         std::shared_ptr<const std::vector<FilterRule>> m_globalFilterRules;
 
-        mutable std::mutex m_localeMutex;
+        mutable detail::SharedMutex m_localeMutex;
         std::atomic<bool> m_hasLocale{false};
         std::string m_locale = "C";
 
@@ -754,7 +755,7 @@ namespace detail {
             std::shared_ptr<const std::vector<PlaceholderInfo>> placeholdersPtr;
             bool cacheHit = false;
             {
-                std::lock_guard<std::mutex> cacheLock(m_cacheMutex);
+                detail::ReadLock<detail::SharedMutex> cacheLock(m_cacheMutex);
                 if (m_templateCacheSize > 0) {
                     auto it = m_templateCache.find(effectiveTemplate);
                     if (it != m_templateCache.end()) {
@@ -766,7 +767,7 @@ namespace detail {
             if (!cacheHit) {
                 auto parsed = extractPlaceholders(effectiveTemplate);
                 placeholdersPtr = std::make_shared<const std::vector<PlaceholderInfo>>(std::move(parsed));
-                std::lock_guard<std::mutex> cacheLock(m_cacheMutex);
+                detail::WriteLock<detail::SharedMutex> cacheLock(m_cacheMutex);
                 if (m_templateCacheSize > 0) {
                     if (m_templateCache.size() < m_templateCacheSize) {
                         m_templateCache[effectiveTemplate] = placeholdersPtr;
@@ -776,7 +777,7 @@ namespace detail {
 
             std::string localeCopy = "C";
             if (m_hasLocale.load(std::memory_order_acquire)) {
-                std::lock_guard<std::mutex> localeLock(m_localeMutex);
+                detail::ReadLock<detail::SharedMutex> localeLock(m_localeMutex);
                 localeCopy = m_locale;
             }
 
@@ -790,7 +791,7 @@ namespace detail {
             bool captureCtx = m_captureSourceLocation.load(std::memory_order_relaxed);
             std::map<std::string, std::string> contextCopy;
             if (m_hasCustomContext.load(std::memory_order_acquire)) {
-                std::lock_guard<std::mutex> contextLock(m_contextMutex);
+                detail::ReadLock<detail::SharedMutex> contextLock(m_contextMutex);
                 contextCopy = m_customContext;
             }
 
@@ -871,7 +872,7 @@ namespace detail {
             std::shared_ptr<const FilterPredicate>& filter,
             std::shared_ptr<const std::vector<FilterRule>>& rules) {
             if (m_hasGlobalFilters.load(std::memory_order_acquire)) {
-                std::lock_guard<std::mutex> flock(m_globalFilterMutex);
+                detail::ReadLock<detail::SharedMutex> flock(m_globalFilterMutex);
                 filter = m_globalFilter;
                 rules  = m_globalFilterRules;
             }

--- a/include/lunar_log/sink/sink_interface.hpp
+++ b/include/lunar_log/sink/sink_interface.hpp
@@ -6,6 +6,7 @@
 #include "../core/filter_rule.hpp"
 #include "../formatter/formatter_interface.hpp"
 #include "../transport/transport_interface.hpp"
+#include "../core/shared_mutex.hpp"
 #include <memory>
 #include <atomic>
 #include <mutex>
@@ -33,7 +34,7 @@ namespace minta {
 
         // --- Tag routing (COW) ---
         void addOnlyTag(const std::string& tag) {
-            std::lock_guard<std::mutex> lock(m_tagMutex);
+            detail::WriteLock<detail::SharedMutex> lock(m_tagMutex);
             auto newTags = std::make_shared<std::set<std::string>>(
                 m_onlyTags ? *m_onlyTags : std::set<std::string>());
             newTags->insert(tag);
@@ -41,7 +42,7 @@ namespace minta {
             m_hasTagFilters.store(true, std::memory_order_release);
         }
         void addExceptTag(const std::string& tag) {
-            std::lock_guard<std::mutex> lock(m_tagMutex);
+            detail::WriteLock<detail::SharedMutex> lock(m_tagMutex);
             auto newTags = std::make_shared<std::set<std::string>>(
                 m_exceptTags ? *m_exceptTags : std::set<std::string>());
             newTags->insert(tag);
@@ -49,27 +50,27 @@ namespace minta {
             m_hasTagFilters.store(true, std::memory_order_release);
         }
         void clearOnlyTags() {
-            std::lock_guard<std::mutex> lock(m_tagMutex);
+            detail::WriteLock<detail::SharedMutex> lock(m_tagMutex);
             m_onlyTags.reset();
             m_hasTagFilters.store(m_exceptTags && !m_exceptTags->empty(), std::memory_order_release);
         }
         void clearExceptTags() {
-            std::lock_guard<std::mutex> lock(m_tagMutex);
+            detail::WriteLock<detail::SharedMutex> lock(m_tagMutex);
             m_exceptTags.reset();
             m_hasTagFilters.store(m_onlyTags && !m_onlyTags->empty(), std::memory_order_release);
         }
         void clearTagFilters() {
-            std::lock_guard<std::mutex> lock(m_tagMutex);
+            detail::WriteLock<detail::SharedMutex> lock(m_tagMutex);
             m_onlyTags.reset();
             m_exceptTags.reset();
             m_hasTagFilters.store(false, std::memory_order_release);
         }
         std::set<std::string> getOnlyTags() const {
-            std::lock_guard<std::mutex> lock(m_tagMutex);
+            detail::ReadLock<detail::SharedMutex> lock(m_tagMutex);
             return m_onlyTags ? *m_onlyTags : std::set<std::string>();
         }
         std::set<std::string> getExceptTags() const {
-            std::lock_guard<std::mutex> lock(m_tagMutex);
+            detail::ReadLock<detail::SharedMutex> lock(m_tagMutex);
             return m_exceptTags ? *m_exceptTags : std::set<std::string>();
         }
 
@@ -86,7 +87,7 @@ namespace minta {
             std::shared_ptr<const std::set<std::string>> onlyTags;
             std::shared_ptr<const std::set<std::string>> exceptTags;
             {
-                std::lock_guard<std::mutex> lock(m_tagMutex);
+                detail::ReadLock<detail::SharedMutex> lock(m_tagMutex);
                 onlyTags = m_onlyTags;
                 exceptTags = m_exceptTags;
             }
@@ -117,19 +118,19 @@ namespace minta {
         ///       Filter predicates must capture state by value.  Referenced
         ///       objects must outlive the logger.
         void setFilter(FilterPredicate filter) {
-            std::lock_guard<std::mutex> lock(m_filterMutex);
+            detail::WriteLock<detail::SharedMutex> lock(m_filterMutex);
             m_filter = std::make_shared<const FilterPredicate>(std::move(filter));
             m_hasFilters.store(true, std::memory_order_release);
         }
 
         void clearFilter() {
-            std::lock_guard<std::mutex> lock(m_filterMutex);
+            detail::WriteLock<detail::SharedMutex> lock(m_filterMutex);
             m_filter.reset();
             m_hasFilters.store(m_filterRules && !m_filterRules->empty(), std::memory_order_release);
         }
 
         void addFilterRule(FilterRule rule) {
-            std::lock_guard<std::mutex> lock(m_filterMutex);
+            detail::WriteLock<detail::SharedMutex> lock(m_filterMutex);
             auto newRules = std::make_shared<std::vector<FilterRule>>(
                 m_filterRules ? *m_filterRules : std::vector<FilterRule>());
             newRules->push_back(std::move(rule));
@@ -139,7 +140,7 @@ namespace minta {
 
         void addFilterRules(std::vector<FilterRule> rules) {
             if (rules.empty()) return;
-            std::lock_guard<std::mutex> lock(m_filterMutex);
+            detail::WriteLock<detail::SharedMutex> lock(m_filterMutex);
             auto newRules = std::make_shared<std::vector<FilterRule>>(
                 m_filterRules ? *m_filterRules : std::vector<FilterRule>());
             newRules->reserve(newRules->size() + rules.size());
@@ -152,7 +153,7 @@ namespace minta {
 
         void addFilterRule(const std::string& ruleStr) {
             FilterRule rule = FilterRule::parse(ruleStr);
-            std::lock_guard<std::mutex> lock(m_filterMutex);
+            detail::WriteLock<detail::SharedMutex> lock(m_filterMutex);
             auto newRules = std::make_shared<std::vector<FilterRule>>(
                 m_filterRules ? *m_filterRules : std::vector<FilterRule>());
             newRules->push_back(std::move(rule));
@@ -161,13 +162,13 @@ namespace minta {
         }
 
         void clearFilterRules() {
-            std::lock_guard<std::mutex> lock(m_filterMutex);
+            detail::WriteLock<detail::SharedMutex> lock(m_filterMutex);
             m_filterRules.reset();
             m_hasFilters.store(m_filter && static_cast<bool>(*m_filter), std::memory_order_release);
         }
 
         void clearAllFilters() {
-            std::lock_guard<std::mutex> lock(m_filterMutex);
+            detail::WriteLock<detail::SharedMutex> lock(m_filterMutex);
             m_filter.reset();
             m_filterRules.reset();
             m_hasFilters.store(false, std::memory_order_release);
@@ -197,7 +198,7 @@ namespace minta {
             std::shared_ptr<const FilterPredicate> filter;
             std::shared_ptr<const std::vector<FilterRule>> rules;
             {
-                std::lock_guard<std::mutex> lock(m_filterMutex);
+                detail::ReadLock<detail::SharedMutex> lock(m_filterMutex);
                 filter = m_filter;
                 rules = m_filterRules;
             }
@@ -232,13 +233,13 @@ namespace minta {
         std::unique_ptr<ITransport> m_transport;
         std::atomic<LogLevel> m_minLevel;
         std::atomic<bool> m_hasFilters;
-        mutable std::mutex m_filterMutex;
+        mutable detail::SharedMutex m_filterMutex;
         std::shared_ptr<const FilterPredicate> m_filter;
         std::shared_ptr<const std::vector<FilterRule>> m_filterRules;
 
         std::string m_sinkName;
         std::atomic<bool> m_hasTagFilters;
-        mutable std::mutex m_tagMutex;
+        mutable detail::SharedMutex m_tagMutex;
         std::shared_ptr<const std::set<std::string>> m_onlyTags;
         std::shared_ptr<const std::set<std::string>> m_exceptTags;
 

--- a/single_include/lunar_log.hpp
+++ b/single_include/lunar_log.hpp
@@ -1742,12 +1742,12 @@ namespace minta {
         /// this locale instead of the logger-level locale stored in the entry.
         /// Thread-safe: can be called concurrently with format().
         void setLocale(const std::string& locale) {
-            std::lock_guard<std::mutex> lock(m_localeMutex);
+            detail::WriteLock<detail::SharedMutex> lock(m_localeMutex);
             m_locale = locale;
         }
 
         std::string getLocale() const {
-            std::lock_guard<std::mutex> lock(m_localeMutex);
+            detail::ReadLock<detail::SharedMutex> lock(m_localeMutex);
             return m_locale;
         }
 
@@ -1759,7 +1759,7 @@ namespace minta {
             // Copy locale under lock, then use the copy outside.
             std::string localeCopy;
             {
-                std::lock_guard<std::mutex> lock(m_localeMutex);
+                detail::ReadLock<detail::SharedMutex> lock(m_localeMutex);
                 localeCopy = m_locale;
             }
             if (localeCopy.empty() || localeCopy == entry.locale) {
@@ -1804,7 +1804,7 @@ namespace minta {
         }
 
     private:
-        mutable std::mutex m_localeMutex;
+        mutable detail::SharedMutex m_localeMutex;
         std::string m_locale;
     };
 } // namespace minta
@@ -2676,7 +2676,7 @@ namespace minta {
 
         // --- Tag routing (COW) ---
         void addOnlyTag(const std::string& tag) {
-            std::lock_guard<std::mutex> lock(m_tagMutex);
+            detail::WriteLock<detail::SharedMutex> lock(m_tagMutex);
             auto newTags = std::make_shared<std::set<std::string>>(
                 m_onlyTags ? *m_onlyTags : std::set<std::string>());
             newTags->insert(tag);
@@ -2684,7 +2684,7 @@ namespace minta {
             m_hasTagFilters.store(true, std::memory_order_release);
         }
         void addExceptTag(const std::string& tag) {
-            std::lock_guard<std::mutex> lock(m_tagMutex);
+            detail::WriteLock<detail::SharedMutex> lock(m_tagMutex);
             auto newTags = std::make_shared<std::set<std::string>>(
                 m_exceptTags ? *m_exceptTags : std::set<std::string>());
             newTags->insert(tag);
@@ -2692,27 +2692,27 @@ namespace minta {
             m_hasTagFilters.store(true, std::memory_order_release);
         }
         void clearOnlyTags() {
-            std::lock_guard<std::mutex> lock(m_tagMutex);
+            detail::WriteLock<detail::SharedMutex> lock(m_tagMutex);
             m_onlyTags.reset();
             m_hasTagFilters.store(m_exceptTags && !m_exceptTags->empty(), std::memory_order_release);
         }
         void clearExceptTags() {
-            std::lock_guard<std::mutex> lock(m_tagMutex);
+            detail::WriteLock<detail::SharedMutex> lock(m_tagMutex);
             m_exceptTags.reset();
             m_hasTagFilters.store(m_onlyTags && !m_onlyTags->empty(), std::memory_order_release);
         }
         void clearTagFilters() {
-            std::lock_guard<std::mutex> lock(m_tagMutex);
+            detail::WriteLock<detail::SharedMutex> lock(m_tagMutex);
             m_onlyTags.reset();
             m_exceptTags.reset();
             m_hasTagFilters.store(false, std::memory_order_release);
         }
         std::set<std::string> getOnlyTags() const {
-            std::lock_guard<std::mutex> lock(m_tagMutex);
+            detail::ReadLock<detail::SharedMutex> lock(m_tagMutex);
             return m_onlyTags ? *m_onlyTags : std::set<std::string>();
         }
         std::set<std::string> getExceptTags() const {
-            std::lock_guard<std::mutex> lock(m_tagMutex);
+            detail::ReadLock<detail::SharedMutex> lock(m_tagMutex);
             return m_exceptTags ? *m_exceptTags : std::set<std::string>();
         }
 
@@ -2729,7 +2729,7 @@ namespace minta {
             std::shared_ptr<const std::set<std::string>> onlyTags;
             std::shared_ptr<const std::set<std::string>> exceptTags;
             {
-                std::lock_guard<std::mutex> lock(m_tagMutex);
+                detail::ReadLock<detail::SharedMutex> lock(m_tagMutex);
                 onlyTags = m_onlyTags;
                 exceptTags = m_exceptTags;
             }
@@ -2760,19 +2760,19 @@ namespace minta {
         ///       Filter predicates must capture state by value.  Referenced
         ///       objects must outlive the logger.
         void setFilter(FilterPredicate filter) {
-            std::lock_guard<std::mutex> lock(m_filterMutex);
+            detail::WriteLock<detail::SharedMutex> lock(m_filterMutex);
             m_filter = std::make_shared<const FilterPredicate>(std::move(filter));
             m_hasFilters.store(true, std::memory_order_release);
         }
 
         void clearFilter() {
-            std::lock_guard<std::mutex> lock(m_filterMutex);
+            detail::WriteLock<detail::SharedMutex> lock(m_filterMutex);
             m_filter.reset();
             m_hasFilters.store(m_filterRules && !m_filterRules->empty(), std::memory_order_release);
         }
 
         void addFilterRule(FilterRule rule) {
-            std::lock_guard<std::mutex> lock(m_filterMutex);
+            detail::WriteLock<detail::SharedMutex> lock(m_filterMutex);
             auto newRules = std::make_shared<std::vector<FilterRule>>(
                 m_filterRules ? *m_filterRules : std::vector<FilterRule>());
             newRules->push_back(std::move(rule));
@@ -2782,7 +2782,7 @@ namespace minta {
 
         void addFilterRules(std::vector<FilterRule> rules) {
             if (rules.empty()) return;
-            std::lock_guard<std::mutex> lock(m_filterMutex);
+            detail::WriteLock<detail::SharedMutex> lock(m_filterMutex);
             auto newRules = std::make_shared<std::vector<FilterRule>>(
                 m_filterRules ? *m_filterRules : std::vector<FilterRule>());
             newRules->reserve(newRules->size() + rules.size());
@@ -2795,7 +2795,7 @@ namespace minta {
 
         void addFilterRule(const std::string& ruleStr) {
             FilterRule rule = FilterRule::parse(ruleStr);
-            std::lock_guard<std::mutex> lock(m_filterMutex);
+            detail::WriteLock<detail::SharedMutex> lock(m_filterMutex);
             auto newRules = std::make_shared<std::vector<FilterRule>>(
                 m_filterRules ? *m_filterRules : std::vector<FilterRule>());
             newRules->push_back(std::move(rule));
@@ -2804,13 +2804,13 @@ namespace minta {
         }
 
         void clearFilterRules() {
-            std::lock_guard<std::mutex> lock(m_filterMutex);
+            detail::WriteLock<detail::SharedMutex> lock(m_filterMutex);
             m_filterRules.reset();
             m_hasFilters.store(m_filter && static_cast<bool>(*m_filter), std::memory_order_release);
         }
 
         void clearAllFilters() {
-            std::lock_guard<std::mutex> lock(m_filterMutex);
+            detail::WriteLock<detail::SharedMutex> lock(m_filterMutex);
             m_filter.reset();
             m_filterRules.reset();
             m_hasFilters.store(false, std::memory_order_release);
@@ -2840,7 +2840,7 @@ namespace minta {
             std::shared_ptr<const FilterPredicate> filter;
             std::shared_ptr<const std::vector<FilterRule>> rules;
             {
-                std::lock_guard<std::mutex> lock(m_filterMutex);
+                detail::ReadLock<detail::SharedMutex> lock(m_filterMutex);
                 filter = m_filter;
                 rules = m_filterRules;
             }
@@ -2875,13 +2875,13 @@ namespace minta {
         std::unique_ptr<ITransport> m_transport;
         std::atomic<LogLevel> m_minLevel;
         std::atomic<bool> m_hasFilters;
-        mutable std::mutex m_filterMutex;
+        mutable detail::SharedMutex m_filterMutex;
         std::shared_ptr<const FilterPredicate> m_filter;
         std::shared_ptr<const std::vector<FilterRule>> m_filterRules;
 
         std::string m_sinkName;
         std::atomic<bool> m_hasTagFilters;
-        mutable std::mutex m_tagMutex;
+        mutable detail::SharedMutex m_tagMutex;
         std::shared_ptr<const std::set<std::string>> m_onlyTags;
         std::shared_ptr<const std::set<std::string>> m_exceptTags;
 
@@ -6387,20 +6387,20 @@ namespace detail {
         ///       Filter predicates must capture state by value.  Referenced
         ///       objects must outlive the logger.
         void setFilter(FilterPredicate filter) {
-            std::lock_guard<std::mutex> lock(m_globalFilterMutex);
+            detail::WriteLock<detail::SharedMutex> lock(m_globalFilterMutex);
             m_globalFilter = std::make_shared<const FilterPredicate>(std::move(filter));
             m_hasGlobalFilters.store(true, std::memory_order_release);
         }
 
         void clearFilter() {
-            std::lock_guard<std::mutex> lock(m_globalFilterMutex);
+            detail::WriteLock<detail::SharedMutex> lock(m_globalFilterMutex);
             m_globalFilter.reset();
             m_hasGlobalFilters.store(m_globalFilterRules && !m_globalFilterRules->empty(), std::memory_order_release);
         }
 
         void addFilterRule(const std::string& ruleStr) {
             FilterRule rule = FilterRule::parse(ruleStr);
-            std::lock_guard<std::mutex> lock(m_globalFilterMutex);
+            detail::WriteLock<detail::SharedMutex> lock(m_globalFilterMutex);
             auto newRules = std::make_shared<std::vector<FilterRule>>(
                 m_globalFilterRules ? *m_globalFilterRules : std::vector<FilterRule>());
             newRules->push_back(std::move(rule));
@@ -6409,13 +6409,13 @@ namespace detail {
         }
 
         void clearFilterRules() {
-            std::lock_guard<std::mutex> lock(m_globalFilterMutex);
+            detail::WriteLock<detail::SharedMutex> lock(m_globalFilterMutex);
             m_globalFilterRules.reset();
             m_hasGlobalFilters.store(m_globalFilter && static_cast<bool>(*m_globalFilter), std::memory_order_release);
         }
 
         void clearAllFilters() {
-            std::lock_guard<std::mutex> lock(m_globalFilterMutex);
+            detail::WriteLock<detail::SharedMutex> lock(m_globalFilterMutex);
             m_globalFilter.reset();
             m_globalFilterRules.reset();
             m_hasGlobalFilters.store(false, std::memory_order_release);
@@ -6428,7 +6428,7 @@ namespace detail {
         void filter(const std::string& compactExpr) {
             std::vector<FilterRule> rules = detail::parseCompactFilter(compactExpr);
             if (rules.empty()) return;
-            std::lock_guard<std::mutex> lock(m_globalFilterMutex);
+            detail::WriteLock<detail::SharedMutex> lock(m_globalFilterMutex);
             auto newRules = std::make_shared<std::vector<FilterRule>>(
                 m_globalFilterRules ? *m_globalFilterRules : std::vector<FilterRule>());
             newRules->reserve(newRules->size() + rules.size());
@@ -6464,19 +6464,19 @@ namespace detail {
         }
 
         void setContext(const std::string& key, const std::string& value) {
-            std::lock_guard<std::mutex> lock(m_contextMutex);
+            detail::WriteLock<detail::SharedMutex> lock(m_contextMutex);
             m_customContext[key] = value;
             m_hasCustomContext.store(true, std::memory_order_release);
         }
 
         void clearContext(const std::string& key) {
-            std::lock_guard<std::mutex> lock(m_contextMutex);
+            detail::WriteLock<detail::SharedMutex> lock(m_contextMutex);
             m_customContext.erase(key);
             m_hasCustomContext.store(!m_customContext.empty(), std::memory_order_release);
         }
 
         void clearAllContext() {
-            std::lock_guard<std::mutex> lock(m_contextMutex);
+            detail::WriteLock<detail::SharedMutex> lock(m_contextMutex);
             m_customContext.clear();
             m_hasCustomContext.store(false, std::memory_order_release);
         }
@@ -6489,7 +6489,7 @@ namespace detail {
         /// they remain accessible for lookups but no new entries are
         /// inserted until the map size drops below the new cap.
         void setTemplateCacheSize(size_t size) {
-            std::lock_guard<std::mutex> lock(m_cacheMutex);
+            detail::WriteLock<detail::SharedMutex> lock(m_cacheMutex);
             m_templateCacheSize = size;
             if (size == 0) {
                 m_templateCache.clear();
@@ -6497,13 +6497,13 @@ namespace detail {
         }
 
         void setLocale(const std::string& locale) {
-            std::lock_guard<std::mutex> lock(m_localeMutex);
+            detail::WriteLock<detail::SharedMutex> lock(m_localeMutex);
             m_locale = locale;
             m_hasLocale.store(locale != "C" && locale != "POSIX" && !locale.empty(), std::memory_order_release);
         }
 
         std::string getLocale() const {
-            std::lock_guard<std::mutex> lock(m_localeMutex);
+            detail::ReadLock<detail::SharedMutex> lock(m_localeMutex);
             return m_locale;
         }
 
@@ -6632,7 +6632,7 @@ namespace detail {
         }
 
         void replaceFilterRules(std::vector<FilterRule> rules) {
-            std::lock_guard<std::mutex> lock(m_globalFilterMutex);
+            detail::WriteLock<detail::SharedMutex> lock(m_globalFilterMutex);
             if (rules.empty()) {
                 m_globalFilterRules.reset();
             } else {
@@ -6650,7 +6650,7 @@ namespace detail {
         std::atomic<bool> m_isRunning;
         std::atomic<long long> m_rateLimitWindowStart;
         std::atomic<size_t> m_logCount;
-        std::mutex m_contextMutex;
+        detail::SharedMutex m_contextMutex;
         LogManager m_logManager;
         std::map<std::string, std::string> m_customContext;
         std::atomic<bool> m_captureSourceLocation;
@@ -6668,16 +6668,16 @@ namespace detail {
             int alignment;   // >0 right-align, <0 left-align, 0 = none
         };
 
-        std::mutex m_cacheMutex;
+        detail::SharedMutex m_cacheMutex;
         std::unordered_map<std::string, std::shared_ptr<const std::vector<PlaceholderInfo>>> m_templateCache;
         size_t m_templateCacheSize;
 
-        std::mutex m_globalFilterMutex;
+        detail::SharedMutex m_globalFilterMutex;
         std::atomic<bool> m_hasGlobalFilters;
         std::shared_ptr<const FilterPredicate> m_globalFilter;
         std::shared_ptr<const std::vector<FilterRule>> m_globalFilterRules;
 
-        mutable std::mutex m_localeMutex;
+        mutable detail::SharedMutex m_localeMutex;
         std::atomic<bool> m_hasLocale{false};
         std::string m_locale = "C";
 
@@ -6754,7 +6754,7 @@ namespace detail {
             std::shared_ptr<const std::vector<PlaceholderInfo>> placeholdersPtr;
             bool cacheHit = false;
             {
-                std::lock_guard<std::mutex> cacheLock(m_cacheMutex);
+                detail::ReadLock<detail::SharedMutex> cacheLock(m_cacheMutex);
                 if (m_templateCacheSize > 0) {
                     auto it = m_templateCache.find(effectiveTemplate);
                     if (it != m_templateCache.end()) {
@@ -6766,7 +6766,7 @@ namespace detail {
             if (!cacheHit) {
                 auto parsed = extractPlaceholders(effectiveTemplate);
                 placeholdersPtr = std::make_shared<const std::vector<PlaceholderInfo>>(std::move(parsed));
-                std::lock_guard<std::mutex> cacheLock(m_cacheMutex);
+                detail::WriteLock<detail::SharedMutex> cacheLock(m_cacheMutex);
                 if (m_templateCacheSize > 0) {
                     if (m_templateCache.size() < m_templateCacheSize) {
                         m_templateCache[effectiveTemplate] = placeholdersPtr;
@@ -6776,7 +6776,7 @@ namespace detail {
 
             std::string localeCopy = "C";
             if (m_hasLocale.load(std::memory_order_acquire)) {
-                std::lock_guard<std::mutex> localeLock(m_localeMutex);
+                detail::ReadLock<detail::SharedMutex> localeLock(m_localeMutex);
                 localeCopy = m_locale;
             }
 
@@ -6790,7 +6790,7 @@ namespace detail {
             bool captureCtx = m_captureSourceLocation.load(std::memory_order_relaxed);
             std::map<std::string, std::string> contextCopy;
             if (m_hasCustomContext.load(std::memory_order_acquire)) {
-                std::lock_guard<std::mutex> contextLock(m_contextMutex);
+                detail::ReadLock<detail::SharedMutex> contextLock(m_contextMutex);
                 contextCopy = m_customContext;
             }
 
@@ -6871,7 +6871,7 @@ namespace detail {
             std::shared_ptr<const FilterPredicate>& filter,
             std::shared_ptr<const std::vector<FilterRule>>& rules) {
             if (m_hasGlobalFilters.load(std::memory_order_acquire)) {
-                std::lock_guard<std::mutex> flock(m_globalFilterMutex);
+                detail::ReadLock<detail::SharedMutex> flock(m_globalFilterMutex);
                 filter = m_globalFilter;
                 rules  = m_globalFilterRules;
             }

--- a/test/tests/test_named_sinks.cpp
+++ b/test/tests/test_named_sinks.cpp
@@ -326,3 +326,145 @@ TEST_F(NamedSinksTest, ThreeSinksWithDifferentLevels) {
     EXPECT_TRUE(errorContent.find("Info msg") == std::string::npos);
     EXPECT_TRUE(errorContent.find("Error msg") != std::string::npos);
 }
+
+
+// ── ISink filter/tag clear methods coverage ─────────────────────────────────
+
+TEST(SinkFilterCoverage, ClearAllFilters) {
+    std::remove("test_clear_all.txt");
+    auto logger = minta::LunarLog::configure()
+        .writeTo<minta::FileSink>("s", "test_clear_all.txt")
+        .build();
+
+    logger.sink("s").filter([](const minta::LogEntry&) { return false; });
+    logger.sink("s").filter("WARN+");
+    logger.info("blocked");
+    logger.flush();
+
+    logger.sink("s").clearFilters();
+    logger.info("visible after clearAll");
+    logger.flush();
+
+    TestUtils::waitForFileContent("test_clear_all.txt");
+    auto content = TestUtils::readLogFile("test_clear_all.txt");
+    EXPECT_TRUE(content.find("blocked") == std::string::npos);
+    EXPECT_TRUE(content.find("visible after clearAll") != std::string::npos);
+}
+
+TEST(SinkFilterCoverage, ClearFilterPredicate) {
+    std::remove("test_clear_pred.txt");
+    auto logger = minta::LunarLog::configure()
+        .writeTo<minta::FileSink>("s", "test_clear_pred.txt")
+        .build();
+
+    logger.sink("s").filter([](const minta::LogEntry&) { return false; });
+    logger.info("blocked");
+    logger.flush();
+
+    logger.sink("s").clearFilter();
+    logger.info("visible after clearFilter");
+    logger.flush();
+
+    TestUtils::waitForFileContent("test_clear_pred.txt");
+    auto content = TestUtils::readLogFile("test_clear_pred.txt");
+    EXPECT_TRUE(content.find("blocked") == std::string::npos);
+    EXPECT_TRUE(content.find("visible after clearFilter") != std::string::npos);
+}
+
+TEST(SinkFilterCoverage, ClearFilterRules) {
+    std::remove("test_clear_rules.txt");
+    auto logger = minta::LunarLog::configure()
+        .writeTo<minta::FileSink>("s", "test_clear_rules.txt")
+        .build();
+
+    logger.sink("s").filter("WARN+");
+    logger.info("filtered out");
+    logger.flush();
+
+    logger.sink("s").clearFilterRules();
+    logger.info("visible after clearRules");
+    logger.flush();
+
+    TestUtils::waitForFileContent("test_clear_rules.txt");
+    auto content = TestUtils::readLogFile("test_clear_rules.txt");
+    EXPECT_TRUE(content.find("filtered out") == std::string::npos);
+    EXPECT_TRUE(content.find("visible after clearRules") != std::string::npos);
+}
+
+TEST(SinkTagCoverage, ClearOnlyTags) {
+    std::remove("test_clear_only.txt");
+    auto logger = minta::LunarLog::configure()
+        .writeTo<minta::FileSink>("s", "test_clear_only.txt")
+        .build();
+
+    logger.sink("s").only("special");
+
+    auto tags = logger.sink("s").getOnlyTags();
+    EXPECT_EQ(tags.size(), 1u);
+    EXPECT_TRUE(tags.count("special"));
+
+    logger.info("untagged blocked");
+    logger.flush();
+
+    logger.sink("s").clearOnlyTags();
+    tags = logger.sink("s").getOnlyTags();
+    EXPECT_TRUE(tags.empty());
+
+    logger.info("untagged visible");
+    logger.flush();
+
+    TestUtils::waitForFileContent("test_clear_only.txt");
+    auto content = TestUtils::readLogFile("test_clear_only.txt");
+    EXPECT_TRUE(content.find("untagged blocked") == std::string::npos);
+    EXPECT_TRUE(content.find("untagged visible") != std::string::npos);
+}
+
+TEST(SinkTagCoverage, ClearExceptTags) {
+    std::remove("test_clear_except.txt");
+    auto logger = minta::LunarLog::configure()
+        .writeTo<minta::FileSink>("s", "test_clear_except.txt")
+        .build();
+
+    logger.sink("s").except("noisy");
+
+    auto tags = logger.sink("s").getExceptTags();
+    EXPECT_EQ(tags.size(), 1u);
+    EXPECT_TRUE(tags.count("noisy"));
+
+    logger.info("[noisy] should be blocked");
+    logger.flush();
+
+    logger.sink("s").clearExceptTags();
+    tags = logger.sink("s").getExceptTags();
+    EXPECT_TRUE(tags.empty());
+
+    logger.info("[noisy] now visible");
+    logger.flush();
+
+    TestUtils::waitForFileContent("test_clear_except.txt");
+    auto content = TestUtils::readLogFile("test_clear_except.txt");
+    EXPECT_TRUE(content.find("should be blocked") == std::string::npos);
+    EXPECT_TRUE(content.find("now visible") != std::string::npos);
+}
+
+TEST(SinkTagCoverage, ClearAllTagFilters) {
+    std::remove("test_clearall_tags.txt");
+    auto logger = minta::LunarLog::configure()
+        .writeTo<minta::FileSink>("s", "test_clearall_tags.txt")
+        .build();
+
+    logger.sink("s").only("a").except("b");
+    logger.sink("s").clearTagFilters();
+
+    auto only = logger.sink("s").getOnlyTags();
+    auto except = logger.sink("s").getExceptTags();
+    EXPECT_TRUE(only.empty());
+    EXPECT_TRUE(except.empty());
+
+    logger.info("all clear");
+    logger.flush();
+
+    TestUtils::waitForFileContent("test_clearall_tags.txt");
+    auto content = TestUtils::readLogFile("test_clearall_tags.txt");
+    EXPECT_TRUE(content.find("all clear") != std::string::npos);
+}

--- a/test/tests/utils/test_utils.cpp
+++ b/test/tests/utils/test_utils.cpp
@@ -231,7 +231,9 @@ void TestUtils::cleanupLogFiles() {
         "dc_test_nochange.json", "dc_test_full.json",
         "dc_nonexistent_config.json",
         "dc_nolevelswitch.txt", "dc_test_nolevelswitch.json",
-        "dc_concurrent.txt", "dc_test_concurrent.json"
+        "dc_concurrent.txt", "dc_test_concurrent.json",
+        "test_clear_all.txt", "test_clear_pred.txt", "test_clear_rules.txt",
+        "test_clear_only.txt", "test_clear_except.txt", "test_clearall_tags.txt"
     };
 
     for (const auto &filename : filesToRemove) {


### PR DESCRIPTION
## Summary

Convert hot-path mutexes from `std::mutex` to `std::shared_mutex` (C++17), with transparent `std::mutex` fallback on C++11/14.

## Problem

`emitLogEntryImpl` acquires exclusive locks on every log call for read-only operations (template cache lookup, locale copy, context snapshot, filter snapshot). Under multi-threaded workloads, this creates unnecessary contention since these are overwhelmingly read-heavy paths.

Same issue in `ISink::passesFilter()` / `shouldAcceptTags()` and `IFormatter::localizedMessage()` — called per log entry per sink.

## Changes

- Add `core/shared_mutex.hpp` with `detail::SharedMutex`, `detail::ReadLock<M>`, `detail::WriteLock<M>` aliases
  - C++17: `shared_mutex` / `shared_lock` / `unique_lock`
  - C++11: `mutex` / `lock_guard` / `unique_lock` (same behavior as before)
- Convert 6 mutex members across 3 files:
  - `log_source.hpp`: `m_cacheMutex`, `m_localeMutex`, `m_contextMutex`, `m_globalFilterMutex`
  - `sink_interface.hpp`: `m_filterMutex`, `m_tagMutex`
  - `formatter_interface.hpp`: `m_localeMutex`
- Hot-path read sites use `ReadLock` (shared), config setter sites use `WriteLock` (exclusive)
- MSVC `_MSVC_LANG` detection for correct C++17 feature gating

## Verification

- All 1151 tests pass
- Benchmarked before/after on Apple M4 Pro (Release, null sink)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Switched internal locking to reader/writer shared mutexes for finer-grained concurrency across filters, locales, tags, template cache and context.
  * Added a portable shared-mutex abstraction with C++17-aware and pre-C++17 fallback.
  * No public API signatures changed for existing methods.

* **New Features**
  * Added proxy methods to clear and retrieve tag filters via the sink proxy interface.

* **Tests**
  * Added tests covering filter and tag clearing and related getters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->